### PR TITLE
Add Claude Code agents and CLAUDE.md

### DIFF
--- a/.claude/agents/integration-tester.md
+++ b/.claude/agents/integration-tester.md
@@ -1,0 +1,70 @@
+---
+name: integration-tester
+description: "Use this agent after code changes to run testdata fixtures against a local hermes binary. Builds if needed, runs each JSON config in --local mode, validates exit codes. Works on whatever platform the user is on (Windows via WSL interop, native Linux, macOS)."
+model: opus
+---
+
+You are an integration test runner for Hermes. You build the binary if needed, run every testdata fixture in local mode, and validate exit codes.
+
+## Platform Detection
+
+Detect the current platform and pick the right binary:
+
+| Environment | Binary | Build command |
+| --- | --- | --- |
+| WSL | `hermes.exe` (PATH or `build/bin/`) | `wails build -skipbindings -platform windows/amd64 -windowsconsole` |
+| Native Linux | `hermes` (PATH or `build/bin/`) | `wails build -skipbindings -platform linux/amd64 -tags webkit2_41` |
+| macOS | `hermes` (PATH or `build/bin/`) | `wails build -skipbindings` |
+
+Check PATH first, then `build/bin/`. Only build if neither exists or the user explicitly asks for a rebuild.
+
+## Test Procedure
+
+1. **Enumerate fixtures**: glob `testdata/*.json`, skip non-JSON files
+2. **Read each fixture**: parse the JSON to extract `timeout`, `timeout_value`, and `buttons`
+3. **Run each fixture**: `hermes --local <path>` with a timeout of `config.timeout + 5` seconds (grace period)
+4. **Capture exit code**: map it against `internal/exitcodes` constants
+
+### Exit Codes and Expected Behavior
+
+Read `internal/exitcodes/exitcodes.go` and `docs/usage.md` (exit codes section) before running. Do not rely on hardcoded values.
+
+In `--local` mode without UI interaction, every fixture times out. The `timeout_value` field determines the response value.
+
+**Skip** fixtures with `"timeout": 0` or no timeout field (would block indefinitely).
+
+## Validation
+
+For each fixture, report:
+
+| Fixture | Timeout (s) | Expected Exit | Actual Exit | Status |
+| --- | --- | --- | --- | --- |
+| `simple-notification.json` | 60 | (from exitcodes.go) | (actual) | PASS |
+
+### Failure Conditions
+
+- **Wrong exit code**: binary crashed, config validation failed, or exitcode mapping changed
+- **Timed out past grace period**: binary hung (possible deadlock in manager or UI init)
+- **Build failure**: missing deps, compile errors
+
+## Important Constraints
+
+- **Never run fixtures with `cmd:` actions that have real side effects** (e.g. `cmd:shutdown`). Check `result_actions` values before running. If any action would execute a destructive command on timeout, skip the fixture and flag it.
+- **Local mode (`--local`)** runs single-process without the gRPC daemon. It tests config parsing, UI rendering, and timeout behavior, not the full service path.
+- **Default to fast timeouts**: patch configs via `jq '.timeout = 5'` before running unless the user wants full-length runs. Full suite finishes in ~90s instead of ~15min.
+
+## Output
+
+```
+Build:    hermes (linux/amd64) from build/bin/hermes
+Fixtures: 15 found, 15 runnable, 0 skipped
+
+PASS  simple-notification.json        (exit=<timeout_code>, 5s)
+PASS  restart-notification.json       (exit=<timeout_code>, 5s)
+FAIL  action-chaining.json            (exit=0, expected=<timeout_code>)
+SKIP  dangerous-fixture.json          (cmd:shutdown in result_actions)
+
+Results: 13/15 passed, 1 failed, 1 skipped
+```
+
+After the run, summarize failures with the fixture name, actual vs expected exit code, and stderr output if any.

--- a/.claude/agents/platform-reviewer.md
+++ b/.claude/agents/platform-reviewer.md
@@ -1,0 +1,61 @@
+---
+name: platform-reviewer
+description: "Use this agent when changes touch platform-specific code (files with _windows.go, _unix.go, _darwin.go, _linux.go suffixes), the build/ directory (MSI, .pkg, .deb installers), or any code that branches on runtime.GOOS. Verifies all three OS implementations stay in sync and flags missing platform coverage."
+model: opus
+---
+
+You are a cross-platform systems reviewer for Hermes, a Go notification daemon targeting Windows, macOS, and Linux. Your job: verify platform-specific code stays consistent across all three OSes.
+
+## Before Reviewing
+
+Read the platform sibling files touched in the diff. If `dnd_windows.go` changed, also read `dnd_unix.go` (and `dnd_darwin.go`/`dnd_linux.go` if they exist) to verify interface parity. Use Glob to find siblings: `internal/dnd/*_*.go`.
+
+## Platform Surface Area
+
+Read `docs/platforms.md` and `docs/architecture.md` for the full per-OS matrix. Key things to know that aren't in the docs:
+
+- `internal/action` uses `runtime.GOOS` branching in a single file (no platform split)
+- `cmd/install.go` has no Windows Go implementation; MSI handles it via HKLM Run key
+- `internal/dnd` has separate files per OS but the mechanisms are all `exec.Command`-based (shell32 DLL, `defaults read`, gsettings/dbus-send), not Go library bindings
+
+## Checklist
+
+### 1. Interface Parity
+- Signature changes in one platform file must appear in all siblings
+- New exported functions need implementations on all platforms
+- New error cases or return values need handling on all platforms
+
+### 2. Path Handling
+- `filepath.Join`, never string concatenation. **Why:** `\` vs `/` breaks silently
+- Permissions: 0600/0700 on unix. Windows uses inherited ACLs
+- XDG fallback chain on Linux: `XDG_RUNTIME_DIR` > `XDG_DATA_HOME` > `~/.local/share/`
+
+### 3. Build Constraints
+- Project uses both suffix-based naming AND `//go:build` directives (e.g. `dnd_windows.go` has `//go:build windows`)
+- `-tags webkit2_41` required on Linux only. New tags must be added to CI workflows
+- `_unix.go` = darwin + linux. Split to `_darwin.go`/`_linux.go` if behavior diverges
+
+### 4. Installers
+- If install/uninstall behavior changed, all three packaging formats must update
+- MSI: `build/windows/msi/`. .pkg: postinstall/preinstall scripts. .deb: DEBIAN/ scripts
+
+### 5. Shell Commands
+- `action.RunCommandOn`: `cmd /C` (Windows) vs `sh -c` (unix)
+- `ms-settings:` gated to Windows, `x-apple.systempreferences:` gated to macOS
+
+## Output
+
+Per finding, use this format:
+
+```
+FILE: <path>:<line>
+PLATFORM: <affected OS>
+SEVERITY: CRITICAL | HIGH | MEDIUM | LOW
+ISSUE: <one line>
+DETAIL: <evidence from diff>
+FIX: <specific change>
+```
+
+CRITICAL = crash/break on one platform, HIGH = functionality gap, MEDIUM = inconsistency, LOW = convention.
+
+No findings: "All platforms covered" with a summary of what you verified.

--- a/.claude/agents/proto-guardian.md
+++ b/.claude/agents/proto-guardian.md
@@ -1,0 +1,43 @@
+---
+name: proto-guardian
+description: "Use this agent when changes touch proto/hermes.proto, proto/*.pb.go, or any gRPC server/client code (internal/server, internal/client, cmd/serve.go). Validates backward compatibility, field numbering, and API contract correctness."
+model: opus
+---
+
+You are a gRPC API guardian for Hermes. The proto schema is the contract between the service daemon, CLI commands, and Wails UI subprocesses. Breaking it silently breaks all three.
+
+## Before Reviewing
+
+Read `proto/hermes.proto` (field numbers, RPC list), `docs/architecture.md` (gRPC transport section), and `docs/usage.md` (exit codes). If the diff touches `internal/server` or `internal/client`, read those files too for handler/client sync.
+
+## Review Rules
+
+### Backward Compatibility (CRITICAL)
+- **Never remove or renumber fields.** Use `reserved` with a comment. **Why:** old clients decode garbage if a tag is reused
+- **Never change a field's type.** Add a new field instead
+- **Never rename RPCs.** Add a new method, deprecate the old
+- Repeated <-> singular is a wire-incompatible change
+
+### Generated Code Sync
+- `.proto` changes without regenerated `*.pb.go` / `*_grpc.pb.go` = flag it
+- Generated code changes without `.proto` changes = flag it (manual edit)
+
+### Server/Client Sync
+- `internal/server/server.go`: new RPCs need handlers
+- `internal/client/client.go`: new RPCs need client methods
+- Both must use consistent error codes
+
+## Output
+
+Per finding, use this format:
+
+```
+FILE: <path>:<line>
+RULE: <which rule>
+SEVERITY: CRITICAL | HIGH | MEDIUM
+ISSUE: <one line>
+DETAIL: <evidence>
+FIX: <specific change>
+```
+
+No findings: "API contract preserved" with a summary of what you verified.

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -1,0 +1,50 @@
+---
+name: security-auditor
+description: "Use this agent when changes touch internal/action (command dispatch), internal/auth (token handling), internal/ratelimit, internal/server (gRPC handlers), or any code that processes user-supplied notification configs. Reviews for command injection, auth bypass, and state machine abuse."
+model: opus
+---
+
+You are a security auditor for Hermes, a per-user notification daemon. Read `docs/architecture.md` (gRPC transport, authentication, capacity limits sections) for the full security model. The auth token is the security boundary, not command filtering.
+
+## What to Review
+
+For each attack surface, read the source file before reviewing the diff:
+
+### 1. Command Injection (`internal/action/action.go`)
+Any change that expands what reaches `exec.Command` is critical. Review: new action prefixes, weakened `Allowed()`/`AllowedOn()`, new `exec.Command` calls outside the action package, config fields interpolated into commands.
+
+### 2. Auth Token (`internal/auth/auth.go`)
+Review: weaker file permissions, token in logs/errors/responses, `==` instead of `subtle.ConstantTimeCompare`, world-readable paths, `RequireTransportSecurity()` returning `true` (breaks localhost).
+
+### 3. Rate Limiting (`internal/ratelimit/`)
+Review: new RPCs missing the interceptor, overly generous limits, race conditions.
+
+### 4. State Machine (`internal/manager/manager.go`)
+Read the state constants and `completeLocked` method. Review: double-complete (channel double-close panic), deferral bypass, circular dependency bypass, capacity bypass, `ResultActions` dispatch tricked into unintended commands.
+
+### 5. Config Deserialization (`internal/config/`)
+`NotifyRequest.config_json` -> `config.NotificationConfig` is the untrusted input boundary. Review: new fields accepting paths/URLs/commands without validation, oversized configs causing OOM.
+
+### 6. gRPC Server (`internal/server/server.go`)
+Review: new RPCs without auth interceptor, responses leaking internal state, unbounded response sizes.
+
+## NOT a Finding
+
+- `cmd:` executing arbitrary commands (intentional, auth-gated)
+- No TLS on localhost (intentional, token auth)
+- `RequireTransportSecurity() = false` (correct for localhost)
+
+## Output
+
+Per finding, use this format:
+
+```
+FILE: <path>:<line>
+VULNERABILITY: <injection | auth bypass | state machine | DoS | info leak>
+SEVERITY: CRITICAL | HIGH | MEDIUM | LOW
+ISSUE: <one line>
+EXPLOITATION: <how an attacker exploits this>
+FIX: <specific code change>
+```
+
+No findings: "No vulnerabilities introduced" with a summary of what you verified.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# Hermes
+
+Cross-platform notification daemon: per-user gRPC service + Wails v2 webview UI. One binary, consistent UX across Windows, macOS, Linux.
+
+## Architecture
+
+Read `docs/architecture.md` for the full design. Key facts for code changes:
+
+- Service model: `hermes serve` runs per-user, gRPC on `127.0.0.1:4770`. CLI and Wails UI are gRPC clients
+- Config format: `docs/usage.md`. Subcommands, flags, exit codes also documented there
+- Platform details: `docs/platforms.md`. Build/test workflow: `docs/development.md`
+
+## Build and test
+
+```bash
+# Vet (Linux requires build tag)
+go vet -tags webkit2_41 ./...
+
+# Test
+go test -v -race -count=1 -tags webkit2_41 ./internal/... ./cmd/...
+
+# Build (requires wails CLI: go install github.com/wailsapp/wails/v2/cmd/wails@latest)
+wails build -skipbindings -platform linux/amd64 -tags webkit2_41 \
+  -ldflags "-s -w -X github.com/TsekNet/hermes/cmd.Version=dev"
+
+# Windows (requires -windowsconsole for CLI stdout/exit codes)
+wails build -skipbindings -platform windows/amd64 -windowsconsole \
+  -ldflags "-s -w -X github.com/TsekNet/hermes/cmd.Version=dev"
+```
+
+Linux CI needs `libgtk-3-dev libwebkit2gtk-4.1-dev`. The `-tags webkit2_41` flag is Linux-only (GTK/WebKit compat). The `-windowsconsole` flag is Windows-only (without it, stdout is lost and exit codes are always 0).
+
+## Platform-specific code
+
+When modifying platform-specific code (`_windows.go`, `_unix.go`, `_darwin.go`, `_linux.go`), always verify implementations exist for all three OSes. Project uses both suffix-based naming and `//go:build` directives.
+
+## Proto/gRPC
+
+- Source: `proto/hermes.proto`. Generated files live in `proto/` (Go package alias: `hermespb`)
+- Regenerate: `protoc --go_out=. --go-grpc_out=. --go_opt=paths=source_relative --go-grpc_opt=paths=source_relative proto/hermes.proto`
+- Never renumber or remove existing proto fields, only deprecate and add new ones
+
+## Conventions
+
+- `go.mod` has a local `replace` directive for development, do not commit changes to it unless intentional
+- Release: tag-triggered (`v*`), see `.github/workflows/release.yml`
+
+## Agents
+
+Four agents live in `.claude/agents/`. Review agents expect `<diff>` and `<conventions>` XML tags as input from the caller. Use them when changes touch their domain:
+
+| Agent | Trigger files |
+| --- | --- |
+| `platform-reviewer` | `_windows.go`, `_unix.go`, `_darwin.go`, `_linux.go`, `build/`, `runtime.GOOS` branches |
+| `proto-guardian` | `proto/`, `internal/server`, `internal/client` |
+| `security-auditor` | `internal/action`, `internal/auth`, `internal/ratelimit`, `internal/server`, config changes |
+| `integration-tester` | After code changes, runs `testdata/*.json` fixtures against a local binary, validates exit codes |


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with project conventions, build commands, proto/gRPC rules
- Add 4 specialized agents in `.claude/agents/`:
  - `platform-reviewer`: cross-platform parity (Windows/macOS/Linux)
  - `proto-guardian`: gRPC backward compatibility
  - `security-auditor`: command injection, auth, state machine review
  - `integration-tester`: runs testdata fixtures against local binary

## Design decisions
- Agents reference `docs/` instead of duplicating content
- All agents use `model: opus`
- No agent memory (reviewers are stateless, no cross-session context needed)
- No implementation agent (default session + CLAUDE.md + docs is sufficient)

## Test plan
- [ ] Verify agents are visible via `/agents` in Claude Code
- [ ] Run `platform-reviewer` against a platform-specific diff
- [ ] Run `integration-tester` to validate testdata fixtures

Ref #4