### PR TITLE
Remove cmd: prefix, harden action dispatch security

### DIFF
--- a/.claude/agents/integration-tester.md
+++ b/.claude/agents/integration-tester.md
@@ -49,7 +49,7 @@ For each fixture, report:
 
 ## Important Constraints
 
-- **Never run fixtures with `cmd:` actions that have real side effects** (e.g. `cmd:shutdown`). Check `result_actions` values before running. If any action would execute a destructive command on timeout, skip the fixture and flag it.
+- **Never run fixtures with destructive `action:` verbs** (e.g. `action:reboot`, `action:shutdown`). Check `result_actions` values before running. If any action would execute a destructive verb on timeout, skip the fixture and flag it.
 - **Local mode (`--local`)** runs single-process without the gRPC daemon. It tests config parsing, UI rendering, and timeout behavior, not the full service path.
 - **Default to fast timeouts**: patch configs via `jq '.timeout = 5'` before running unless the user wants full-length runs. Full suite finishes in ~90s instead of ~15min.
 
@@ -62,7 +62,7 @@ Fixtures: 15 found, 15 runnable, 0 skipped
 PASS  simple-notification.json        (exit=<timeout_code>, 5s)
 PASS  restart-notification.json       (exit=<timeout_code>, 5s)
 FAIL  action-chaining.json            (exit=0, expected=<timeout_code>)
-SKIP  dangerous-fixture.json          (cmd:shutdown in result_actions)
+SKIP  dangerous-fixture.json          (action:reboot in result_actions)
 
 Results: 13/15 passed, 1 failed, 1 skipped
 ```

--- a/.claude/agents/security-auditor.md
+++ b/.claude/agents/security-auditor.md
@@ -30,7 +30,7 @@ Review: new RPCs without auth interceptor, responses leaking internal state, unb
 
 ## NOT a Finding
 
-- `cmd:` executing arbitrary commands (intentional, auth-gated)
+- `action:` verbs invoking platform commands (intentional, hardcoded, auth-gated)
 - No TLS on localhost (intentional, token auth)
 - `RequireTransportSecurity() = false` (correct for localhost)
 

--- a/README.md
+++ b/README.md
@@ -84,13 +84,13 @@ The service tracks deferrals per notification, persisted to disk. When the user 
 | **Image carousel** | Embed slides/screenshots via HTTPS URLs or data URIs. Arrow key navigation. |
 | **Filesystem watch** | Monitor paths for changes (e.g. wait for install receipt). UI updates live. |
 | **Do Not Disturb** | Detects OS Focus/DND mode. Default: wait and retry. Also: skip or ignore. |
-| **Settings URIs** | `url:ms-settings:windowsupdate` (Windows), `url:x-apple.systempreferences:...` (macOS). Platform-filtered at runtime. |
+| **Settings URIs** | `uri:ms-settings:windowsupdate` (Windows), `uri:x-apple.systempreferences:...` (macOS). Platform-filtered at runtime. |
 | **Countdown timer** | Auto-action after timeout. Configurable value returned to calling script. |
 | **Inbox / history** | Completed notifications are persisted. View past actions via `hermes inbox` (UI or JSON). Auto-pruned by age and count. |
 | **Offline queue** | Service unreachable? Notification is persisted locally and delivered on next startup. Exit 203. |
 | **Priority** | Control delivery order (0-10). Higher priority notifications drain first. |
 | **Escalation ladder** | Progressive urgency after repeated deferrals — shorter timeout, warning color, urgency text. |
-| **Action chaining** | Map user responses to automatic follow-up actions (`cmd:` or `url:` prefix). |
+| **Action chaining** | Map user responses to automatic follow-up actions (`action:` or `uri:` prefix). |
 | **Quiet hours** | Time-based delivery suppression. Overnight ranges supported. |
 | **Localization** | `heading_localized` / `message_localized` maps + `--locale` flag for multi-language notifications. |
 | **Dependencies** | Sequential workflows: notification B waits for notification A to complete. |

--- a/cmd/demo.go
+++ b/cmd/demo.go
@@ -31,8 +31,8 @@ func demoConfig() *config.NotificationConfig {
 				Label: "Explore",
 				Style: "secondary",
 				Dropdown: []config.DropdownOption{
-					{Label: "View Docs", Value: "url:https://github.com/TsekNet/hermes#readme"},
-					{Label: "View Source", Value: "url:https://github.com/TsekNet/hermes"},
+					{Label: "View Docs", Value: "uri:https://github.com/TsekNet/hermes#readme"},
+					{Label: "View Source", Value: "uri:https://github.com/TsekNet/hermes"},
 				},
 			},
 			{Label: "Got it", Value: "ok", Style: "primary"},

--- a/cmd/inbox.go
+++ b/cmd/inbox.go
@@ -28,8 +28,8 @@ func inboxCmd() *cobra.Command {
 		Use:   "inbox",
 		Short: "View notification history",
 		Long: `Opens the notification history UI showing past notifications, or prints
-history as JSON. Action buttons in the history view execute cmd:-prefixed
-response values (e.g. "cmd:shutdown /r /t 0") via the platform shell.`,
+history as JSON. Action buttons in the history view re-execute the original
+action (uri: opens the URI, action: runs the built-in verb).`,
 		Example: `  hermes inbox
   hermes inbox --json`,
 		RunE: func(_ *cobra.Command, _ []string) error {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,7 +44,7 @@ sequenceDiagram
 5. **Launch** — Service launches a UI subprocess directly (same user session).
 6. **Response** — User clicks a button. UI reports choice via `ReportChoice` RPC. `Notify` RPC unblocks and returns the value.
 7. **Defer + Escalation** — User defers. Manager increments defer count, starts an internal timer, and re-launches the UI when the timer fires. If `escalation` thresholds are configured, the notification's appearance and timeout mutate progressively (shorter timeout, warning color, urgency text).
-8. **Action chaining** — When the notification completes, the manager checks `result_actions` for a mapping from the user's response value to an automatic action (`cmd:` or `url:` prefix). The action is dispatched server-side.
+8. **Action chaining** — When the notification completes, the manager checks `result_actions` for a mapping from the user's response value to an automatic action (`uri:` or `action:` prefix). The action is dispatched server-side.
 9. **Deadline** — If `defer_deadline` is set and the deadline passes, the notification auto-actions with `timeout_value`. Deadlines are enforced even while waiting for DND or quiet hours to clear.
 10. **Cancel** — External `Cancel` RPC removes the notification and unblocks the `Notify` RPC.
 
@@ -79,15 +79,22 @@ The `result_actions` map connects user responses to automatic follow-up actions.
 ```json
 {
   "result_actions": {
-    "restart": "cmd:shutdown /r /t 60",
-    "wiki": "url:https://wiki.example.com/vpn-troubleshooting"
+    "restart": "action:reboot",
+    "wiki": "uri:https://wiki.example.com/vpn-troubleshooting"
   }
 }
 ```
 
-Supported action prefixes: `cmd:` (shell command), `url:` (opens in default browser / system handler). The action runs in the service daemon process, not the UI subprocess.
+Supported action prefixes:
 
-> **Security note:** `cmd:` actions execute with the same privileges as the `hermes serve` process (the logged-in user). Only trusted configs should define `result_actions`. Configs are validated on enqueue and drain, but the shell command itself is passed to `sh -c` / `cmd /C` without further sandboxing.
+| Prefix | Behavior |
+|--------|----------|
+| `uri:` | Opens the URI in the default system handler. Only allowlisted schemes are permitted (see [`allowedSchemes` in action.go](../internal/action/action.go)). |
+| `action:` | Executes a built-in verb with platform-specific implementations (see [`validVerbs` in action.go](../internal/action/action.go) and `builtin_*.go` for per-platform details). |
+
+The action runs in the service daemon process, not the UI subprocess. Shell execution from config is not supported. To run arbitrary commands on a notification result, read the response value from stdout in the calling script and dispatch externally.
+
+> **Security note:** `action:` verbs invoke platform commands with fixed implementations (no shell interpolation). Only trusted configs should define `result_actions`.
 
 ---
 
@@ -233,7 +240,7 @@ hermes/
 │   ├── ratelimit/                 Token-bucket rate limiter for gRPC RPCs
 │   ├── server/                    gRPC server implementation
 │   ├── store/                     bbolt persistence (deferral state + offline queue)
-│   ├── action/                    Button value dispatch (url:, cmd:, ms-settings:, x-apple.systempreferences:)
+│   ├── action/                    Button value dispatch (uri:, action:)
 │   └── watch/                     Filesystem monitoring (fsnotify wrapper)
 │
 ├── frontend/                      The web UI (embedded into binary)
@@ -382,7 +389,7 @@ JS communicates with Go through Wails runtime bindings:
 
 **Inbox view (`InboxApp`):**
 - `GetHistory()` — return completed notification entries
-- `RunAction(id, value)` — re-execute a `cmd:`-prefixed action from history
+- `RunAction(id, value)` — re-execute a `uri:` or `action:` button from history
 - `Ready()` — center and show the inbox window
 
 Wails event channels:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -108,37 +108,30 @@ hermes accepts a single JSON or YAML config with these fields:
 
 **Styles:** `primary` (accent color), `secondary` (dark with border), `danger` (red).
 
-### URL and settings URI buttons
+### URI buttons
 
-Button values prefixed with `url:` open the URI in the default handler instead of closing the notification. Hermes supports platform-specific settings URIs alongside standard web URLs:
+Button values prefixed with `uri:` open the URI in the default system handler instead of closing the notification. Only schemes on the allowlist are permitted. The canonical list lives in [`internal/action/action.go`](../internal/action/action.go) (`allowedSchemes` variable). Schemes not on this list are rejected at validation time.
 
-| Scheme | Platform | Example |
-|--------|----------|---------|
-| `https:` | All | `url:https://example.com/kb/update` |
-| `http:` | All | `url:http://intranet.corp/install` |
-| `ms-settings:` | Windows | `url:ms-settings:windowsupdate` |
-| `x-apple.systempreferences:` | macOS | `url:x-apple.systempreferences:com.apple.Software-Update-Settings.extension` |
-
-Settings URIs are only allowed on their native platform. A `ms-settings:` button on macOS is silently blocked (and vice versa). Include both in a shared config -- hermes filters at runtime.
+Platform-specific schemes (e.g. `ms-settings:`) are delegated to the OS default handler. A `ms-settings:` button on macOS will fail gracefully since the OS has no handler registered.
 
 ```json
-{"label": "Windows Update", "value": "url:ms-settings:windowsupdate", "style": "primary"}
-{"label": "Software Update", "value": "url:x-apple.systempreferences:com.apple.Software-Update-Settings.extension", "style": "primary"}
-{"label": "FileVault", "value": "url:x-apple.systempreferences:com.apple.preference.security?FileVault", "style": "secondary"}
+{"label": "Windows Update", "value": "uri:ms-settings:windowsupdate", "style": "primary"}
+{"label": "Software Update", "value": "uri:x-apple.systempreferences:com.apple.Software-Update-Settings.extension", "style": "primary"}
+{"label": "FileVault", "value": "uri:x-apple.systempreferences:com.apple.preference.security?FileVault", "style": "secondary"}
 ```
 
 macOS pane IDs follow the pattern `com.apple.preference.<name>` or `com.apple.<Name>-Settings.extension`. Append `?Anchor` for sub-panes (e.g. `?FileVault`, `?Privacy_AllFiles`). Linux has no standard settings URI scheme.
 
-### Command buttons
+### Action buttons
 
-Button values prefixed with `cmd:` execute a shell command when clicked. The command runs through the platform shell (`cmd /C` on Windows, `sh -c` on Unix). Arguments, pipes, and shell features are supported.
+Button values prefixed with `action:` execute a built-in verb. No shell is invoked, no user input reaches the argument vector. The canonical verb list lives in [`internal/action/action.go`](../internal/action/action.go) (`validVerbs` variable). Platform implementations are in the `builtin_*.go` files in the same package.
 
 ```json
-{"label": "Restart Now", "value": "cmd:shutdown /r /t 0", "style": "primary"}
-{"label": "Reboot", "value": "cmd:sudo shutdown -r now", "style": "danger"}
+{"label": "Restart Now", "value": "action:reboot", "style": "primary"}
+{"label": "Lock Screen", "value": "action:lock", "style": "secondary"}
 ```
 
-Commands are also re-executable from the inbox history view. Empty commands (`cmd:` with no argument) are blocked. Only one primary button per notification is recommended -- the Enter key triggers the first primary button.
+Shell execution from config is not supported. To run arbitrary commands on a notification result, read the response value from stdout in the calling script and dispatch externally. Only one primary button per notification is recommended, the Enter key triggers the first primary button.
 
 ### Deferral config
 
@@ -200,7 +193,7 @@ Monitor filesystem paths for changes during the notification. When a watched pat
   ],
   "timeout": 600,
   "buttons": [
-    {"label": "Install", "value": "url:https://intranet.example.com/install", "style": "primary"}
+    {"label": "Install", "value": "uri:https://intranet.example.com/install", "style": "primary"}
   ]
 }
 ```
@@ -280,13 +273,13 @@ Map user responses to automatic follow-up actions. The action runs server-side a
     {"label": "Open Wiki", "value": "wiki", "style": "secondary"}
   ],
   "result_actions": {
-    "restart": "cmd:shutdown /r /t 60",
-    "wiki": "url:https://wiki.example.com/vpn"
+    "restart": "action:reboot",
+    "wiki": "uri:https://wiki.example.com/vpn"
   }
 }
 ```
 
-Supported prefixes: `cmd:` (shell command) and `url:` (opens in browser). Actions also fire on timeout if `timeout_value` matches a key (e.g. `"timeout:restart"` matches `"restart"`).
+Supported prefixes: `uri:` (opens in system handler, see [`allowedSchemes`](../internal/action/action.go)) and `action:` (built-in verb, see [`validVerbs`](../internal/action/action.go)). Actions also fire on timeout if `timeout_value` matches a key (e.g. `"timeout:restart"` matches `"restart"`).
 
 ### Quiet hours
 
@@ -384,6 +377,8 @@ The second notification is held in `waiting_on_dependency` state until the first
 ---
 
 ## Exit codes
+
+Exit code constants are defined in [`internal/exitcodes/exitcodes.go`](../internal/exitcodes/exitcodes.go). Key values:
 
 | Code | Meaning |
 |------|---------|

--- a/frontend/main.js
+++ b/frontend/main.js
@@ -314,7 +314,7 @@
 
   function onButtonClick(e) {
     var value = e.target.getAttribute("data-value");
-    if (value && value.indexOf("url:") === 0) {
+    if (value && value.toLowerCase().indexOf("uri:") === 0) {
       if (Backend) Backend.Respond(value);
       return;
     }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/wailsapp/wails/v2 v2.11.0
 	go.etcd.io/bbolt v1.4.3
+	golang.org/x/sys v0.39.0
 	google.golang.org/grpc v1.79.1
 	google.golang.org/protobuf v1.36.10
 	gopkg.in/yaml.v3 v3.0.1
@@ -41,7 +42,6 @@ require (
 	github.com/wailsapp/mimetype v1.4.1 // indirect
 	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/net v0.48.0 // indirect
-	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 )

--- a/internal/action/action.go
+++ b/internal/action/action.go
@@ -1,13 +1,14 @@
-// Package action validates, classifies, and executes button response values.
-// Values use a prefix scheme: url: opens a browser, cmd: runs a shell command,
-// ms-settings: / x-apple.systempreferences: open platform settings panels,
-// and plain values are returned as-is.
+// Package action validates, classifies, and executes notification response values.
+// Values use a prefix scheme: uri: opens a URI via the OS default handler,
+// action: runs a built-in verb (reboot, shutdown, lock), and plain values
+// are returned as-is to the calling script via the manager layer.
+//
+// The cmd: prefix is explicitly rejected. Shell execution from config input
+// is not permitted. URI schemes use an allowlist, not a denylist.
 package action
 
 import (
 	"fmt"
-	"net/url"
-	"os/exec"
 	"runtime"
 	"strings"
 
@@ -19,26 +20,46 @@ import (
 type Kind int
 
 const (
-	KindUnknown  Kind = iota
-	KindWeb           // http, https
-	KindSettings      // platform settings panel
-	KindCommand       // shell command execution
+	KindUnknown Kind = iota
+	KindURI          // uri: prefix, opened by OS default handler
+	KindBuiltin      // action: prefix, compiled verb (reboot, shutdown, lock)
 )
 
-// Scheme is a registered action prefix with its kind and platform constraint.
-type Scheme struct {
-	Prefix   string // prefix including ":" (e.g. "cmd:")
-	Kind     Kind
-	Platform string // GOOS value, or "" for all platforms
-	Example  string
+var allowedSchemes = []string{
+	"https:",
+	"http:",
+	"ms-settings:",
+	"x-apple.systempreferences:",
+	"slack:",
+	"msteams:",
+	"companyportal:",
+	"codex:",
 }
 
-var registry = []Scheme{
-	{Prefix: "https:", Kind: KindWeb, Example: "https://example.com"},
-	{Prefix: "http:", Kind: KindWeb, Example: "http://intranet.corp/kb"},
-	{Prefix: "ms-settings:", Kind: KindSettings, Platform: "windows", Example: "ms-settings:windowsupdate"},
-	{Prefix: "x-apple.systempreferences:", Kind: KindSettings, Platform: "darwin", Example: "x-apple.systempreferences:com.apple.preference.security"},
-	{Prefix: "cmd:", Kind: KindCommand, Example: "cmd:shutdown /r /t 0"},
+var validVerbs = []string{"reboot", "shutdown", "lock"}
+
+// ValidVerbs returns the list of supported action: verbs.
+func ValidVerbs() []string {
+	out := make([]string, len(validVerbs))
+	copy(out, validVerbs)
+	return out
+}
+
+// AllowedSchemes returns the list of URI schemes permitted by the allowlist.
+func AllowedSchemes() []string {
+	out := make([]string, len(allowedSchemes))
+	copy(out, allowedSchemes)
+	return out
+}
+
+// IsURI reports whether value uses the uri: prefix.
+func IsURI(value string) bool {
+	return strings.HasPrefix(strings.ToLower(value), "uri:")
+}
+
+// IsBuiltin reports whether value uses the action: prefix.
+func IsBuiltin(value string) bool {
+	return strings.HasPrefix(strings.ToLower(value), "action:")
 }
 
 // Allowed reports whether value is permitted on the current OS.
@@ -47,117 +68,119 @@ func Allowed(value string) bool {
 }
 
 // AllowedOn reports whether value is permitted on the given OS.
+// The goos parameter is accepted for test-time cross-platform verification
+// but does not currently gate any scheme or verb by platform.
 func AllowedOn(value, goos string) bool {
 	lower := strings.ToLower(value)
-	for _, s := range registry {
-		if !strings.HasPrefix(lower, s.Prefix) {
-			continue
-		}
-		if s.Platform != "" && s.Platform != goos {
+
+	if strings.HasPrefix(lower, "cmd:") {
+		return false
+	}
+
+	if strings.HasPrefix(lower, "uri:") {
+		body := uriBody(value)
+		if body == "" {
 			return false
 		}
-		if s.Kind == KindCommand {
-			return strings.TrimSpace(value[len("cmd:"):]) != ""
-		}
-		_, err := url.Parse(value)
-		return err == nil
+		return isAllowedScheme(body)
 	}
+
+	if strings.HasPrefix(lower, "action:") {
+		return isValidVerb(actionVerb(value))
+	}
+
 	return false
 }
 
 // ClassifyOn returns the Kind of a value on the given OS.
 func ClassifyOn(value, goos string) Kind {
 	lower := strings.ToLower(value)
-	for _, s := range registry {
-		if strings.HasPrefix(lower, s.Prefix) {
-			if s.Platform != "" && s.Platform != goos {
-				return KindUnknown
-			}
-			return s.Kind
+
+	if strings.HasPrefix(lower, "uri:") {
+		body := uriBody(value)
+		if body == "" || !isAllowedScheme(body) {
+			return KindUnknown
 		}
+		return KindURI
 	}
+
+	if strings.HasPrefix(lower, "action:") {
+		if isValidVerb(actionVerb(value)) {
+			return KindBuiltin
+		}
+		return KindUnknown
+	}
+
 	return KindUnknown
 }
 
-// SettingsSchemes returns the settings schemes available on the given OS.
-func SettingsSchemes(goos string) []Scheme {
-	var out []Scheme
-	for _, s := range registry {
-		if s.Kind == KindSettings && (s.Platform == "" || s.Platform == goos) {
-			out = append(out, s)
-		}
+// OpenURI opens a URI via the OS default handler after checking the allowlist.
+func OpenURI(uri string) error {
+	uri = strings.TrimSpace(uri)
+	if uri == "" {
+		return fmt.Errorf("empty URI")
 	}
-	return out
-}
-
-// AllSchemes returns every registered scheme available on the given OS.
-func AllSchemes(goos string) []Scheme {
-	var out []Scheme
-	for _, s := range registry {
-		if s.Platform == "" || s.Platform == goos {
-			out = append(out, s)
-		}
+	if !isAllowedScheme(uri) {
+		return fmt.Errorf("URI scheme not allowed: %s", uri)
 	}
-	return out
+	deck.Infof("action: open URI %q", uri)
+	return browser.OpenURL(uri)
 }
 
-// IsCommand reports whether value uses the cmd: prefix.
-func IsCommand(value string) bool {
-	return strings.HasPrefix(strings.ToLower(value), "cmd:")
-}
-
-// CommandString extracts the shell command from a cmd: value.
-func CommandString(value string) string {
-	if len(value) <= len("cmd:") {
-		return ""
+// RunBuiltin executes a built-in action verb on the current OS.
+func RunBuiltin(verb string) error {
+	verb = strings.ToLower(strings.TrimSpace(verb))
+	if !isValidVerb(verb) {
+		return fmt.Errorf("unknown action verb: %q", verb)
 	}
-	return strings.TrimSpace(value[len("cmd:"):])
-}
-
-// RunCommand executes a cmd:-prefixed value via the platform shell.
-func RunCommand(value string) (string, error) {
-	return RunCommandOn(value, runtime.GOOS)
+	deck.Infof("action: builtin %q (os=%s)", verb, runtime.GOOS)
+	return platformRunBuiltin(verb)
 }
 
 // Dispatch executes an action string from the server side (no Wails context).
-// Handles url:, cmd:, and platform settings prefixes. Returns nil for plain
-// values that don't match any action prefix. Used by the manager for
-// resultActions (action chaining after notification completion).
+// Handles uri: and action: prefixes. Returns nil for plain values (the manager
+// layer reads these from the Notify response). Rejects cmd: with an error.
 func Dispatch(value string) error {
-	// Strip "url:" wrapper — same as the frontend app layer does.
-	if strings.HasPrefix(value, "url:") {
-		uri := strings.TrimPrefix(value, "url:")
-		if !Allowed(uri) {
-			return fmt.Errorf("blocked URI: %s", uri)
-		}
-		deck.Infof("action: dispatch url %q", uri)
-		return browser.OpenURL(uri)
+	lower := strings.ToLower(value)
+
+	if strings.HasPrefix(lower, "cmd:") {
+		return fmt.Errorf("cmd: prefix is not supported, use action: or uri: instead")
 	}
-	if IsCommand(value) {
-		if !Allowed(value) {
-			return fmt.Errorf("blocked command: %s", value)
-		}
-		out, err := RunCommand(value)
-		if err != nil {
-			return fmt.Errorf("command failed: %w: %s", err, out)
-		}
-		return nil
+
+	if strings.HasPrefix(lower, "uri:") {
+		return OpenURI(uriBody(value))
 	}
+
+	if strings.HasPrefix(lower, "action:") {
+		return RunBuiltin(actionVerb(value))
+	}
+
 	return nil
 }
 
-// RunCommandOn executes a cmd:-prefixed value using the shell for the given OS.
-// Exported for cross-platform testing.
-func RunCommandOn(value, goos string) (string, error) {
-	cmdStr := CommandString(value)
-	deck.Infof("action: exec %q (os=%s)", cmdStr, goos)
+func uriBody(value string) string {
+	return strings.TrimSpace(value[len("uri:"):])
+}
 
-	var cmd *exec.Cmd
-	if goos == "windows" {
-		cmd = exec.Command("cmd", "/C", cmdStr)
-	} else {
-		cmd = exec.Command("sh", "-c", cmdStr)
+func actionVerb(value string) string {
+	return strings.ToLower(strings.TrimSpace(value[len("action:"):]))
+}
+
+func isAllowedScheme(uri string) bool {
+	lower := strings.ToLower(uri)
+	for _, s := range allowedSchemes {
+		if strings.HasPrefix(lower, s) {
+			return true
+		}
 	}
-	out, err := cmd.CombinedOutput()
-	return string(out), err
+	return false
+}
+
+func isValidVerb(verb string) bool {
+	for _, v := range validVerbs {
+		if v == verb {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/action/action_test.go
+++ b/internal/action/action_test.go
@@ -15,39 +15,86 @@ func TestAllowedOn(t *testing.T) {
 		goos  string
 		want  bool
 	}{
-		{"https any platform", "https://example.com", "windows", true},
-		{"http any platform", "http://intranet/kb", "darwin", true},
+		// uri: with allowed schemes
+		{"https any platform", "uri:https://example.com", "windows", true},
+		{"http any platform", "uri:http://intranet/kb", "darwin", true},
+		{"ms-settings on windows", "uri:ms-settings:windowsupdate", "windows", true},
+		{"ms-settings on mac", "uri:ms-settings:windowsupdate", "darwin", true},
+		{"ms-settings on linux", "uri:ms-settings:windowsupdate", "linux", true},
+		{"apple prefs on darwin", "uri:x-apple.systempreferences:com.apple.preference.security", "darwin", true},
+		{"apple prefs on windows", "uri:x-apple.systempreferences:com.apple.preference.security", "windows", true},
+		{"companyportal scheme", "uri:companyportal://apps", "windows", true},
+		{"slack scheme", "uri:slack://channel?team=T1&id=C1", "linux", true},
+		{"msteams scheme", "uri:msteams://teams.microsoft.com/l/chat", "windows", true},
+		{"codex scheme", "uri:codex://context?repo=example", "linux", true},
 
-		{"ms-settings on windows", "ms-settings:windowsupdate", "windows", true},
-		{"ms-settings on mac blocked", "ms-settings:windowsupdate", "darwin", false},
-		{"ms-settings on linux blocked", "ms-settings:windowsupdate", "linux", false},
+		// uri: schemes NOT in allowlist are rejected
+		{"custom scheme rejected", "uri:myapp://open", "linux", false},
+		{"smb rejected", "uri:smb://server/share", "windows", false},
+		{"file rejected", "uri:file:///etc/passwd", "linux", false},
+		{"javascript rejected", "uri:javascript:alert(1)", "darwin", false},
+		{"data rejected", "uri:data:text/html,<script>alert(1)</script>", "linux", false},
+		{"vbscript rejected", "uri:vbscript:MsgBox(1)", "windows", false},
+		{"ms-msdt rejected", "uri:ms-msdt:/id PCWDiagnostic", "windows", false},
+		{"ftp rejected", "uri:ftp://evil.com/payload", "linux", false},
+		{"ldap rejected", "uri:ldap://attacker.com", "windows", false},
+		{"ssh rejected", "uri:ssh://attacker.com", "linux", false},
+		{"telnet rejected", "uri:telnet://attacker.com", "windows", false},
+		{"mailto rejected", "uri:mailto:user@example.com", "linux", false},
+		{"tel rejected", "uri:tel:+15551234567", "darwin", false},
 
-		{"apple prefs on mac", "x-apple.systempreferences:com.apple.preference.security", "darwin", true},
-		{"apple prefs on windows blocked", "x-apple.systempreferences:com.apple.preference.security", "windows", false},
-		{"apple prefs on linux blocked", "x-apple.systempreferences:com.apple.preference.security", "linux", false},
+		// uri: allowlist is case-insensitive (scheme matching)
+		{"HTTPS allowed uppercase", "uri:HTTPS://example.com", "linux", true},
+		{"Http allowed mixed", "uri:Http://example.com", "darwin", true},
 
-		{"apple prefs with anchor", "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles", "darwin", true},
-		{"ms-settings with path", "ms-settings:windowsupdate-action", "windows", true},
+		// uri: path-like values rejected (no valid scheme)
+		{"windows drive path rejected", "uri:C:\\Windows\\System32\\calc.exe", "windows", false},
+		{"unc path rejected", "uri:\\\\server\\share", "windows", false},
+		{"unix absolute path rejected", "uri:/etc/passwd", "linux", false},
+		{"percent-encoded scheme rejected", "uri:%66ile:///etc/passwd", "linux", false},
 
-		{"ftp blocked", "ftp://evil.com/payload", "windows", false},
-		{"file blocked", "file:///etc/passwd", "linux", false},
-		{"javascript blocked", "javascript:alert(1)", "darwin", false},
+		// uri: case-insensitive prefix
+		{"URI prefix uppercase", "URI:https://example.com", "linux", true},
+		{"Uri prefix mixed", "Uri:https://example.com", "darwin", true},
+
+		// uri: edge cases
+		{"uri: empty body", "uri:", "linux", false},
+		{"uri: whitespace only", "uri:   ", "linux", false},
+
+		// action: valid verbs
+		{"action:reboot on windows", "action:reboot", "windows", true},
+		{"action:reboot on darwin", "action:reboot", "darwin", true},
+		{"action:reboot on linux", "action:reboot", "linux", true},
+		{"action:shutdown on windows", "action:shutdown", "windows", true},
+		{"action:shutdown on darwin", "action:shutdown", "darwin", true},
+		{"action:shutdown on linux", "action:shutdown", "linux", true},
+		{"action:lock on windows", "action:lock", "windows", true},
+		{"action:lock on darwin", "action:lock", "darwin", true},
+		{"action:lock on linux", "action:lock", "linux", true},
+
+		// action: case-insensitive prefix and verb
+		{"ACTION prefix uppercase", "ACTION:reboot", "linux", true},
+		{"Action prefix mixed", "Action:Reboot", "windows", true},
+
+		// action: invalid verbs
+		{"action:unknown verb", "action:restart", "linux", false},
+		{"action:empty verb", "action:", "linux", false},
+		{"action:arbitrary string", "action:rm -rf /", "linux", false},
+
+		// cmd: rejected everywhere
+		{"cmd: on windows", "cmd:shutdown /r /t 0", "windows", false},
+		{"cmd: on darwin", "cmd:osascript -e 'restart'", "darwin", false},
+		{"cmd: on linux", "cmd:systemctl reboot", "linux", false},
+		{"CMD: uppercase", "CMD:echo hello", "linux", false},
+
+		// bare schemes (no uri: prefix) rejected
+		{"bare https", "https://example.com", "linux", false},
+		{"bare http", "http://example.com", "windows", false},
+		{"bare ms-settings", "ms-settings:windowsupdate", "windows", false},
+
+		// plain values
+		{"plain value", "restart", "linux", false},
 		{"empty string", "", "windows", false},
-		{"bare path", "/tmp/foo", "linux", false},
-
-		{"case insensitive https", "HTTPS://EXAMPLE.COM", "linux", true},
-		{"case insensitive ms-settings", "MS-SETTINGS:windowsupdate", "windows", true},
-		{"case insensitive apple prefs", "X-Apple.SystemPreferences:com.apple.preference.security", "darwin", true},
-
-		{"cmd on windows", "cmd:shutdown /r /t 0", "windows", true},
-		{"cmd on mac", "cmd:osascript -e 'tell app \"Finder\" to restart'", "darwin", true},
-		{"cmd on linux", "cmd:systemctl reboot", "linux", true},
-		{"cmd case insensitive", "CMD:echo hello", "windows", true},
-		{"cmd empty command", "cmd:", "windows", false},
-		{"cmd whitespace only", "cmd:   ", "linux", false},
-		{"cmd with args", "cmd:powershell.exe -Command Get-Process", "windows", true},
-		{"cmd with pipe", "cmd:echo hello | grep hello", "linux", true},
-		{"cmd with quotes", `cmd:bash -c "echo test"`, "darwin", true},
 	}
 
 	for _, tt := range tests {
@@ -69,16 +116,19 @@ func TestClassifyOn(t *testing.T) {
 		goos  string
 		want  Kind
 	}{
-		{"https is web", "https://example.com", "linux", KindWeb},
-		{"http is web", "http://example.com", "windows", KindWeb},
-		{"ms-settings is settings", "ms-settings:windowsupdate", "windows", KindSettings},
-		{"apple prefs is settings", "x-apple.systempreferences:com.apple.preference.security", "darwin", KindSettings},
-		{"ms-settings wrong platform", "ms-settings:windowsupdate", "darwin", KindUnknown},
-		{"cmd is command", "cmd:shutdown /r /t 0", "windows", KindCommand},
-		{"cmd any platform", "cmd:echo hi", "linux", KindCommand},
-		{"cmd on mac", "cmd:open /Applications", "darwin", KindCommand},
-		{"unknown scheme", "ftp://x.com", "linux", KindUnknown},
-		{"plain value", "restart", "windows", KindUnknown},
+		{"uri:https is URI", "uri:https://example.com", "linux", KindURI},
+		{"uri:http is URI", "uri:http://example.com", "windows", KindURI},
+		{"uri:ms-settings is URI", "uri:ms-settings:windowsupdate", "windows", KindURI},
+		{"uri:unknown scheme is unknown", "uri:myapp://open", "linux", KindUnknown},
+		{"uri:file is unknown", "uri:file:///etc/passwd", "linux", KindUnknown},
+		{"action:reboot is builtin", "action:reboot", "linux", KindBuiltin},
+		{"action:shutdown is builtin", "action:shutdown", "windows", KindBuiltin},
+		{"action:lock is builtin", "action:lock", "darwin", KindBuiltin},
+		{"action:unknown is unknown", "action:restart", "linux", KindUnknown},
+		{"cmd: is unknown", "cmd:echo hi", "linux", KindUnknown},
+		{"plain value is unknown", "restart", "windows", KindUnknown},
+		{"bare https is unknown", "https://example.com", "linux", KindUnknown},
+		{"empty is unknown", "", "linux", KindUnknown},
 	}
 
 	for _, tt := range tests {
@@ -91,167 +141,38 @@ func TestClassifyOn(t *testing.T) {
 	}
 }
 
-func TestSettingsSchemes(t *testing.T) {
+func TestValidVerbs(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		goos      string
-		wantCount int
-		wantFirst string
-	}{
-		{"windows", 1, "ms-settings:"},
-		{"darwin", 1, "x-apple.systempreferences:"},
-		{"linux", 0, ""},
+	verbs := ValidVerbs()
+	if len(verbs) != 3 {
+		t.Fatalf("len(ValidVerbs()) = %d, want 3", len(verbs))
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.goos, func(t *testing.T) {
-			t.Parallel()
-			got := SettingsSchemes(tt.goos)
-			if len(got) != tt.wantCount {
-				t.Fatalf("len = %d, want %d", len(got), tt.wantCount)
-			}
-			if tt.wantCount > 0 && got[0].Prefix != tt.wantFirst {
-				t.Errorf("prefix = %q, want %q", got[0].Prefix, tt.wantFirst)
-			}
-		})
-	}
-}
-
-func TestAllSchemes(t *testing.T) {
-	t.Parallel()
-
-	win := AllSchemes("windows")
-	mac := AllSchemes("darwin")
-	lin := AllSchemes("linux")
-
-	if len(win) != 4 {
-		t.Errorf("windows schemes = %d, want 4 (https, http, ms-settings, cmd)", len(win))
-	}
-	if len(mac) != 4 {
-		t.Errorf("darwin schemes = %d, want 4 (https, http, x-apple.systempreferences, cmd)", len(mac))
-	}
-	if len(lin) != 3 {
-		t.Errorf("linux schemes = %d, want 3 (https, http, cmd)", len(lin))
-	}
-}
-
-func TestIsCommand(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		value string
-		want  bool
-	}{
-		{"cmd:echo hi", true},
-		{"CMD:echo hi", true},
-		{"Cmd:echo hi", true},
-		{"url:https://x.com", false},
-		{"restart", false},
-		{"", false},
-		{"cmd:", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.value, func(t *testing.T) {
-			t.Parallel()
-			if got := IsCommand(tt.value); got != tt.want {
-				t.Errorf("IsCommand(%q) = %v, want %v", tt.value, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestCommandString(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		value string
-		want  string
-	}{
-		{"cmd:echo hi", "echo hi"},
-		{"cmd: shutdown /r /t 0", "shutdown /r /t 0"},
-		{"cmd:  spaces  ", "spaces"},
-		{"cmd:powershell.exe -Command Get-Process", "powershell.exe -Command Get-Process"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.value, func(t *testing.T) {
-			t.Parallel()
-			if got := CommandString(tt.value); got != tt.want {
-				t.Errorf("CommandString(%q) = %q, want %q", tt.value, got, tt.want)
-			}
-		})
-	}
-}
-
-func TestRunCommand(t *testing.T) {
-	t.Parallel()
-
-	if runtime.GOOS == "windows" {
-		t.Run("echo on windows", func(t *testing.T) {
-			t.Parallel()
-			out, err := RunCommand("cmd:echo hello")
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if !strings.Contains(out, "hello") {
-				t.Errorf("output = %q, want contains 'hello'", out)
-			}
-		})
-
-		t.Run("powershell on windows", func(t *testing.T) {
-			t.Parallel()
-			out, err := RunCommand("cmd:powershell.exe -Command \"Write-Output 'test123'\"")
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if !strings.Contains(out, "test123") {
-				t.Errorf("output = %q, want contains 'test123'", out)
-			}
-		})
-	} else {
-		t.Run("echo on unix", func(t *testing.T) {
-			t.Parallel()
-			out, err := RunCommand("cmd:echo hello")
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if strings.TrimSpace(out) != "hello" {
-				t.Errorf("output = %q, want 'hello'", out)
-			}
-		})
-
-		t.Run("pipe on unix", func(t *testing.T) {
-			t.Parallel()
-			out, err := RunCommand("cmd:echo abc123 | grep abc")
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if !strings.Contains(out, "abc123") {
-				t.Errorf("output = %q, want contains 'abc123'", out)
-			}
-		})
-
-		t.Run("args with spaces", func(t *testing.T) {
-			t.Parallel()
-			out, err := RunCommand("cmd:printf '%s %s' hello world")
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if strings.TrimSpace(out) != "hello world" {
-				t.Errorf("output = %q, want 'hello world'", out)
-			}
-		})
-	}
-
-	t.Run("bad command fails", func(t *testing.T) {
-		t.Parallel()
-		_, err := RunCommand("cmd:__nonexistent_binary_xyz__")
-		if err == nil {
-			t.Fatal("expected error for nonexistent command")
+	want := map[string]bool{"reboot": true, "shutdown": true, "lock": true}
+	for _, v := range verbs {
+		if !want[v] {
+			t.Errorf("unexpected verb %q", v)
 		}
-	})
+	}
+}
+
+func TestAllowedSchemes(t *testing.T) {
+	t.Parallel()
+
+	schemes := AllowedSchemes()
+	want := []string{
+		"https:", "http:", "ms-settings:", "x-apple.systempreferences:",
+		"slack:", "msteams:", "companyportal:", "codex:",
+	}
+	if len(schemes) != len(want) {
+		t.Fatalf("len(AllowedSchemes()) = %d, want %d", len(schemes), len(want))
+	}
+	for i, s := range schemes {
+		if s != want[i] {
+			t.Errorf("AllowedSchemes()[%d] = %q, want %q", i, s, want[i])
+		}
+	}
 }
 
 func TestDispatch(t *testing.T) {
@@ -271,43 +192,166 @@ func TestDispatch(t *testing.T) {
 		}
 	})
 
-	if runtime.GOOS != "windows" {
-		t.Run("cmd echo succeeds", func(t *testing.T) {
-			t.Parallel()
-			if err := Dispatch("cmd:echo dispatch_test"); err != nil {
-				t.Errorf("Dispatch(cmd:echo) = %v", err)
-			}
-		})
-
-		t.Run("cmd bad command fails", func(t *testing.T) {
-			t.Parallel()
-			if err := Dispatch("cmd:__nonexistent_xyz__"); err == nil {
-				t.Error("expected error for bad command")
-			}
-		})
-	}
-
-	t.Run("blocked URI returns error", func(t *testing.T) {
+	t.Run("cmd: returns error", func(t *testing.T) {
 		t.Parallel()
-		err := Dispatch("url:ftp://evil.com")
+		err := Dispatch("cmd:echo hello")
 		if err == nil {
-			t.Error("expected error for blocked URI")
+			t.Fatal("expected error for cmd: value")
 		}
-		if err != nil && !strings.Contains(err.Error(), "blocked") {
-			t.Errorf("error = %q, want contains 'blocked'", err)
+		if !strings.Contains(err.Error(), "cmd:") {
+			t.Errorf("error = %q, want contains 'cmd:'", err)
+		}
+	})
+
+	t.Run("uri: unknown scheme returns error", func(t *testing.T) {
+		t.Parallel()
+		err := Dispatch("uri:file:///etc/passwd")
+		if err == nil {
+			t.Fatal("expected error for unknown URI scheme")
+		}
+		if !strings.Contains(err.Error(), "not allowed") {
+			t.Errorf("error = %q, want contains 'not allowed'", err)
+		}
+	})
+
+	t.Run("action: invalid verb returns error", func(t *testing.T) {
+		t.Parallel()
+		err := Dispatch("action:rm -rf /")
+		if err == nil {
+			t.Fatal("expected error for unknown action verb")
+		}
+		if !strings.Contains(err.Error(), "unknown") {
+			t.Errorf("error = %q, want contains 'unknown'", err)
 		}
 	})
 }
 
-func TestRunCommandOn(t *testing.T) {
+func TestRunBuiltin(t *testing.T) {
 	t.Parallel()
 
-	// RunCommandOn with current OS should behave the same as RunCommand.
-	out, err := RunCommandOn("cmd:echo crossplatform", runtime.GOOS)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	t.Run("invalid verb returns error", func(t *testing.T) {
+		t.Parallel()
+		err := RunBuiltin("restart")
+		if err == nil {
+			t.Fatal("expected error for unknown verb")
+		}
+	})
+
+	t.Run("empty verb returns error", func(t *testing.T) {
+		t.Parallel()
+		err := RunBuiltin("")
+		if err == nil {
+			t.Fatal("expected error for empty verb")
+		}
+	})
+}
+
+func TestOpenURI(t *testing.T) {
+	t.Parallel()
+
+	t.Run("file scheme not in allowlist", func(t *testing.T) {
+		t.Parallel()
+		err := OpenURI("file:///etc/passwd")
+		if err == nil {
+			t.Fatal("expected error for file scheme")
+		}
+		if !strings.Contains(err.Error(), "not allowed") {
+			t.Errorf("error = %q, want contains 'not allowed'", err)
+		}
+	})
+
+	t.Run("empty URI returns error", func(t *testing.T) {
+		t.Parallel()
+		err := OpenURI("")
+		if err == nil {
+			t.Fatal("expected error for empty URI")
+		}
+	})
+
+	t.Run("smb not in allowlist", func(t *testing.T) {
+		t.Parallel()
+		err := OpenURI("smb://server/share")
+		if err == nil {
+			t.Fatal("expected error for smb scheme")
+		}
+	})
+
+	t.Run("path-like value rejected", func(t *testing.T) {
+		t.Parallel()
+		err := OpenURI("C:\\Windows\\System32\\calc.exe")
+		if err == nil {
+			t.Fatal("expected error for path-like value")
+		}
+	})
+}
+
+func TestIsURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{"uri:https://example.com", true},
+		{"URI:https://example.com", true},
+		{"Uri:ms-settings:windowsupdate", true},
+		{"uri:", true},
+		{"url:https://example.com", false},
+		{"cmd:echo hi", false},
+		{"action:reboot", false},
+		{"restart", false},
+		{"", false},
 	}
-	if !strings.Contains(out, "crossplatform") {
-		t.Errorf("output = %q, want contains 'crossplatform'", out)
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			t.Parallel()
+			if got := IsURI(tt.value); got != tt.want {
+				t.Errorf("IsURI(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
 	}
+}
+
+func TestIsBuiltin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{"action:reboot", true},
+		{"ACTION:REBOOT", true},
+		{"action:shutdown", true},
+		{"action:lock", true},
+		{"action:restart", true},
+		{"action:", true},
+		{"cmd:echo", false},
+		{"uri:https://example.com", false},
+		{"restart", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			t.Parallel()
+			if got := IsBuiltin(tt.value); got != tt.want {
+				t.Errorf("IsBuiltin(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNoShellExecution(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cmd prefix functions removed", func(t *testing.T) {
+		t.Parallel()
+		if ClassifyOn("cmd:echo hello", runtime.GOOS) != KindUnknown {
+			t.Error("cmd: should classify as KindUnknown")
+		}
+		if AllowedOn("cmd:echo hello", runtime.GOOS) {
+			t.Error("cmd: should not be allowed")
+		}
+	})
 }

--- a/internal/action/builtin_darwin.go
+++ b/internal/action/builtin_darwin.go
@@ -1,0 +1,29 @@
+//go:build darwin
+
+// macOS builtins use absolute SIP-protected paths. Pure Go cannot call
+// Carbon/Cocoa APIs (IOKit, AppKit) without cgo. These binaries are in
+// paths protected by System Integrity Protection and cannot be tampered with.
+
+package action
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func platformRunBuiltin(verb string) error {
+	switch verb {
+	case "reboot":
+		return exec.Command("/usr/bin/osascript", "-e",
+			`tell application "System Events" to restart`).Run()
+	case "shutdown":
+		return exec.Command("/usr/bin/osascript", "-e",
+			`tell application "System Events" to shut down`).Run()
+	case "lock":
+		return exec.Command(
+			"/System/Library/CoreServices/Menu Extras/User.menu/Contents/Resources/CGSession",
+			"-suspend").Run()
+	default:
+		return fmt.Errorf("unknown verb: %q", verb)
+	}
+}

--- a/internal/action/builtin_linux.go
+++ b/internal/action/builtin_linux.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+// Linux builtins use absolute paths to systemd binaries. Pure syscalls
+// (unix.Reboot) require CAP_SYS_BOOT which a per-user daemon does not have.
+// The alternative is D-Bus IPC to systemd-logind, but that adds a dependency
+// (godbus/dbus). These paths are package-managed and root-owned.
+
+package action
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+func platformRunBuiltin(verb string) error {
+	switch verb {
+	case "reboot":
+		return exec.Command("/usr/bin/systemctl", "reboot").Run()
+	case "shutdown":
+		return exec.Command("/usr/bin/systemctl", "poweroff").Run()
+	case "lock":
+		// lock-session without args locks the calling process's session,
+		// which requires hermes to run as a user-session service (not system).
+		return exec.Command("/usr/bin/loginctl", "lock-session").Run()
+	default:
+		return fmt.Errorf("unknown verb: %q", verb)
+	}
+}

--- a/internal/action/builtin_windows.go
+++ b/internal/action/builtin_windows.go
@@ -1,0 +1,97 @@
+//go:build windows
+
+package action
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	ewxReboot      = 0x02
+	ewxPowerOff    = 0x08
+	ewxForceIfHung = 0x10
+
+	shtdnReasonFlagPlanned = 0x80000000
+
+	seShutdownName = "SeShutdownPrivilege"
+)
+
+var (
+	modUser32           = windows.NewLazySystemDLL("user32.dll")
+	procExitWindowsEx   = modUser32.NewProc("ExitWindowsEx")
+	procLockWorkStation = modUser32.NewProc("LockWorkStation")
+)
+
+func platformRunBuiltin(verb string) error {
+	switch verb {
+	case "reboot":
+		if err := enableShutdownPrivilege(); err != nil {
+			return fmt.Errorf("enable shutdown privilege: %w", err)
+		}
+		return exitWindowsEx(ewxReboot | ewxForceIfHung)
+	case "shutdown":
+		if err := enableShutdownPrivilege(); err != nil {
+			return fmt.Errorf("enable shutdown privilege: %w", err)
+		}
+		return exitWindowsEx(ewxPowerOff | ewxForceIfHung)
+	case "lock":
+		return lockWorkStation()
+	default:
+		return fmt.Errorf("unknown verb: %q", verb)
+	}
+}
+
+func exitWindowsEx(flags uint32) error {
+	r, _, err := procExitWindowsEx.Call(
+		uintptr(flags),
+		uintptr(shtdnReasonFlagPlanned),
+	)
+	if r == 0 {
+		return fmt.Errorf("ExitWindowsEx: %w", err)
+	}
+	return nil
+}
+
+func lockWorkStation() error {
+	r, _, err := procLockWorkStation.Call()
+	if r == 0 {
+		return fmt.Errorf("LockWorkStation: %w", err)
+	}
+	return nil
+}
+
+func enableShutdownPrivilege() error {
+	var token windows.Token
+	err := windows.OpenProcessToken(windows.CurrentProcess(),
+		windows.TOKEN_ADJUST_PRIVILEGES|windows.TOKEN_QUERY, &token)
+	if err != nil {
+		return fmt.Errorf("OpenProcessToken: %w", err)
+	}
+	defer token.Close()
+
+	var luid windows.LUID
+	name, _ := windows.UTF16PtrFromString(seShutdownName)
+	err = windows.LookupPrivilegeValue(nil, name, &luid)
+	if err != nil {
+		return fmt.Errorf("LookupPrivilegeValue: %w", err)
+	}
+
+	tp := windows.Tokenprivileges{
+		PrivilegeCount: 1,
+		Privileges: [1]windows.LUIDAndAttributes{
+			{Luid: luid, Attributes: windows.SE_PRIVILEGE_ENABLED},
+		},
+	}
+
+	err = windows.AdjustTokenPrivileges(token, false, &tp, uint32(unsafe.Sizeof(tp)), nil, nil)
+	if err != nil {
+		return fmt.Errorf("AdjustTokenPrivileges: %w", err)
+	}
+	if errno := windows.GetLastError(); errno == windows.ERROR_NOT_ALL_ASSIGNED {
+		return fmt.Errorf("AdjustTokenPrivileges: privilege not held")
+	}
+	return nil
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -4,7 +4,6 @@ package app
 import (
 	"context"
 	goRuntime "runtime"
-	"strings"
 	"time"
 
 	"github.com/TsekNet/hermes/internal/config"
@@ -127,18 +126,17 @@ func (a *App) Ready() {
 	wailsRuntime.WindowShow(a.ctx)
 }
 
-// Respond handles the user's choice. Opens URLs, runs commands, sends gRPC, quits.
+// Respond handles the user's choice. Opens URIs, runs builtins, sends gRPC, quits.
 func (a *App) Respond(value string) {
-	if strings.HasPrefix(value, "url:") {
-		a.openURL(strings.TrimPrefix(value, "url:"))
+	if action.IsURI(value) {
+		a.openURI(value[len("uri:"):])
 		return
 	}
 
-	if action.IsCommand(value) {
-		if !action.Allowed(value) {
-			deck.Warningf("blocked command: %s", value)
-		} else if out, err := action.RunCommand(value); err != nil {
-			deck.Errorf("cmd: %v: %s", err, out)
+	if action.IsBuiltin(value) {
+		verb := value[len("action:"):]
+		if err := action.RunBuiltin(verb); err != nil {
+			deck.Errorf("action: %v", err)
 		}
 	}
 
@@ -163,14 +161,13 @@ func (a *App) Respond(value string) {
 // OpenHelp opens the help URL in the default browser.
 func (a *App) OpenHelp() {
 	if a.cfg.HelpURL != "" {
-		a.openURL(a.cfg.HelpURL)
+		a.openURI(a.cfg.HelpURL)
 	}
 }
 
-func (a *App) openURL(rawURL string) {
-	if !action.Allowed(rawURL) {
-		deck.Warningf("blocked URI: %s", rawURL)
+func (a *App) openURI(rawURI string) {
+	if err := action.OpenURI(rawURI); err != nil {
+		deck.Warningf("open URI: %v", err)
 		return
 	}
-	wailsRuntime.BrowserOpenURL(a.ctx, rawURL)
 }

--- a/internal/app/inbox.go
+++ b/internal/app/inbox.go
@@ -94,15 +94,15 @@ func InboxEntryFromClientEntry(e client.HistoryEntry) InboxEntry {
 	}
 }
 
-// RunAction executes a cmd:-prefixed value, or returns the plain value.
+// RunAction re-opens a uri:-prefixed value from history. Only uri: is
+// supported from the inbox: re-running action:reboot from history would
+// be a footgun.
 func (a *InboxApp) RunAction(id, value string) string {
 	deck.Infof("inbox: action %s -> %s", id, value)
-	if action.IsCommand(value) {
-		if !action.Allowed(value) {
-			return "blocked"
-		}
-		if out, err := action.RunCommand(value); err != nil {
-			deck.Errorf("inbox: command failed: %v: %s", err, out)
+	if action.IsURI(value) {
+		uri := value[len("uri:"):]
+		if err := action.OpenURI(uri); err != nil {
+			deck.Errorf("inbox: open URI failed: %v", err)
 			return "error: " + err.Error()
 		}
 		return "ok"

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -39,6 +39,9 @@ func testCfg(id string) *config.NotificationConfig {
 		TimeoutSeconds: 10,
 		TimeoutValue:   "auto",
 		ID:             id,
+		Buttons: []config.Button{
+			{Label: "OK", Value: "ok"},
+		},
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,8 +69,7 @@ type NotificationConfig struct {
 	Escalation []EscalationStep `json:"escalation,omitempty" yaml:"escalation,omitempty"`
 
 	// ResultActions maps response values to automatic follow-up actions.
-	// Keys are button values (e.g. "restart"), values use the same prefix
-	// scheme as buttons: "cmd:shutdown /r /t 60", "url:https://...".
+	// Keys are button values (e.g. "restart"), values use "uri:" or "action:" prefixes.
 	// The action is dispatched server-side after the notification completes.
 	ResultActions map[string]string `json:"result_actions,omitempty" yaml:"result_actions,omitempty"`
 
@@ -207,6 +206,28 @@ type Button struct {
 type DropdownOption struct {
 	Label string `json:"label" yaml:"label"`
 	Value string `json:"value" yaml:"value"`
+}
+
+// HasValue reports whether value is a known response for this config:
+// any button value, dropdown value, timeout_value, or esc_value.
+func (c *NotificationConfig) HasValue(value string) bool {
+	if value == "" {
+		return false
+	}
+	if value == c.TimeoutValue || value == c.EscValue {
+		return true
+	}
+	for _, b := range c.Buttons {
+		if b.Value == value {
+			return true
+		}
+		for _, d := range b.Dropdown {
+			if d.Value == value {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // MaxConfigSize is the maximum allowed config payload (64 KB).
@@ -374,12 +395,20 @@ func (c *NotificationConfig) Validate() error {
 		errs = append(errs, `"message" is required`)
 	}
 	for i := range c.Buttons {
-		if strings.ContainsAny(c.Buttons[i].Value, "\n\r") {
+		bv := c.Buttons[i].Value
+		if strings.ContainsAny(bv, "\n\r") {
 			errs = append(errs, "button values must not contain newlines")
 		}
+		if strings.HasPrefix(strings.ToLower(bv), "cmd:") {
+			errs = append(errs, fmt.Sprintf("buttons[%d]: cmd: prefix is not allowed, use action: or uri: instead", i))
+		}
 		for j := range c.Buttons[i].Dropdown {
-			if strings.ContainsAny(c.Buttons[i].Dropdown[j].Value, "\n\r") {
+			dv := c.Buttons[i].Dropdown[j].Value
+			if strings.ContainsAny(dv, "\n\r") {
 				errs = append(errs, "dropdown values must not contain newlines")
+			}
+			if strings.HasPrefix(strings.ToLower(dv), "cmd:") {
+				errs = append(errs, fmt.Sprintf("buttons[%d].dropdown[%d]: cmd: prefix is not allowed, use action: or uri: instead", i, j))
 			}
 		}
 	}
@@ -440,9 +469,10 @@ func (c *NotificationConfig) Validate() error {
 			errs = append(errs, fmt.Sprintf("result_actions key %q: must not contain newlines", k))
 		}
 		lower := strings.ToLower(v)
-		if !strings.HasPrefix(lower, "cmd:") && !strings.HasPrefix(lower, "url:") &&
-			!strings.HasPrefix(lower, "https:") && !strings.HasPrefix(lower, "http:") {
-			errs = append(errs, fmt.Sprintf("result_actions[%q]: value must start with cmd:, url:, https:, or http:", k))
+		if strings.HasPrefix(lower, "cmd:") {
+			errs = append(errs, fmt.Sprintf("result_actions[%q]: cmd: prefix is not allowed, use action: or uri: instead", k))
+		} else if !strings.HasPrefix(lower, "uri:") && !strings.HasPrefix(lower, "action:") {
+			errs = append(errs, fmt.Sprintf("result_actions[%q]: value must start with uri: or action:", k))
 		}
 	}
 	if c.DependsOn != "" && c.DependsOn == c.ID {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -153,6 +153,33 @@ func TestValidate(t *testing.T) {
 				Buttons: []Button{{Label: "OK", Value: "ok"}},
 			},
 		},
+		{
+			name: "cmd: in button value rejected",
+			cfg: NotificationConfig{
+				Heading: "H", Message: "M",
+				Buttons: []Button{{Label: "Run", Value: "cmd:shutdown /r /t 0"}},
+			},
+			wantErr:   true,
+			errSubstr: "cmd: prefix is not allowed",
+		},
+		{
+			name: "CMD: in button value rejected (case-insensitive)",
+			cfg: NotificationConfig{
+				Heading: "H", Message: "M",
+				Buttons: []Button{{Label: "Run", Value: "CMD:echo hello"}},
+			},
+			wantErr:   true,
+			errSubstr: "cmd: prefix is not allowed",
+		},
+		{
+			name: "cmd: in dropdown value rejected",
+			cfg: NotificationConfig{
+				Heading: "H", Message: "M",
+				Buttons: []Button{{Label: "D", Dropdown: []DropdownOption{{Label: "X", Value: "cmd:echo"}}}},
+			},
+			wantErr:   true,
+			errSubstr: "cmd: prefix is not allowed",
+		},
 	}
 
 	for _, tt := range tests {
@@ -820,15 +847,20 @@ func TestValidate_ResultActions(t *testing.T) {
 		errSubstr string
 	}{
 		{"nil is valid", nil, false, ""},
-		{"valid cmd", map[string]string{"restart": "cmd:shutdown /r /t 60"}, false, ""},
-		{"valid url", map[string]string{"wiki": "url:https://wiki.example.com"}, false, ""},
-		{"valid https", map[string]string{"wiki": "https://wiki.example.com"}, false, ""},
+		{"valid uri https", map[string]string{"wiki": "uri:https://wiki.example.com"}, false, ""},
+		{"valid uri ms-settings", map[string]string{"settings": "uri:ms-settings:windowsupdate"}, false, ""},
+		{"valid action reboot", map[string]string{"restart": "action:reboot"}, false, ""},
+		{"valid action shutdown", map[string]string{"halt": "action:shutdown"}, false, ""},
+		{"valid action lock", map[string]string{"lock": "action:lock"}, false, ""},
+		{"cmd rejected", map[string]string{"restart": "cmd:shutdown /r /t 60"}, true, "cmd: prefix is not allowed"},
+		{"bare https rejected", map[string]string{"wiki": "https://wiki.example.com"}, true, "must start with uri: or action:"},
+		{"bare http rejected", map[string]string{"wiki": "http://wiki.example.com"}, true, "must start with uri: or action:"},
 		{"bad prefix", map[string]string{"restart": "ftp://evil.com"}, true, "result_actions"},
-		{"key with newline", map[string]string{"bad\nkey": "cmd:echo"}, true, "newlines"},
+		{"key with newline", map[string]string{"bad\nkey": "uri:https://x.com"}, true, "newlines"},
 		{"too many actions", func() map[string]string {
 			m := make(map[string]string, 11)
 			for i := range 11 {
-				m[fmt.Sprintf("k%d", i)] = fmt.Sprintf("cmd:echo %d", i)
+				m[fmt.Sprintf("k%d", i)] = fmt.Sprintf("uri:https://x.com/%d", i)
 			}
 			return m
 		}(), true, "exceeds maximum"},
@@ -1106,3 +1138,44 @@ quiet_hours:
 	}
 }
 
+
+func TestHasValue(t *testing.T) {
+	t.Parallel()
+
+	cfg := NotificationConfig{
+		Heading:      "H",
+		Message:      "M",
+		TimeoutValue: "timeout",
+		EscValue:     "esc",
+		Buttons: []Button{
+			{Label: "OK", Value: "ok"},
+			{Label: "Menu", Dropdown: []DropdownOption{
+				{Label: "A", Value: "opt-a"},
+				{Label: "B", Value: "opt-b"},
+			}},
+		},
+	}
+
+	tests := []struct {
+		value string
+		want  bool
+	}{
+		{"ok", true},
+		{"opt-a", true},
+		{"opt-b", true},
+		{"timeout", true},
+		{"esc", true},
+		{"unknown", false},
+		{"cmd:echo", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.value, func(t *testing.T) {
+			t.Parallel()
+			if got := cfg.HasValue(tt.value); got != tt.want {
+				t.Errorf("HasValue(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -251,9 +251,13 @@ func (m *Manager) ReportChoice(id, value string) bool {
 		return false
 	}
 
-	// Deferral handling.
 	if strings.HasPrefix(value, "defer") {
 		return m.handleDeferLocked(n, value)
+	}
+
+	if !n.Config.HasValue(value) {
+		deck.Warningf("manager: rejecting unknown value %q for %s", value, id)
+		return false
 	}
 
 	return m.completeLocked(n, value)

--- a/internal/manager/manager_test.go
+++ b/internal/manager/manager_test.go
@@ -16,6 +16,13 @@ func testConfig(heading string) *config.NotificationConfig {
 		Message:        "Test message",
 		TimeoutSeconds: 10,
 		TimeoutValue:   "auto_action",
+		EscValue:       "timeout:restart",
+		Buttons: []config.Button{
+			{Label: "OK", Value: "ok"},
+			{Label: "Restart", Value: "restart"},
+			{Label: "Defer", Value: "defer_4h"},
+			{Label: "Timeout", Value: "timeout"},
+		},
 	}
 }
 
@@ -142,6 +149,22 @@ func TestReportChoice(t *testing.T) {
 				t.Fatal("timeout waiting for result")
 			}
 		})
+	}
+}
+
+func TestReportChoice_RejectsUnknownValue(t *testing.T) {
+	t.Parallel()
+	mgr := New(nil, nil)
+	id, _ := mgr.Submit(testConfig("S5"))
+
+	ok := mgr.ReportChoice(id, "cmd:evil")
+	if ok {
+		t.Fatal("ReportChoice accepted unknown value 'cmd:evil'")
+	}
+
+	ok = mgr.ReportChoice(id, "crafted_key")
+	if ok {
+		t.Fatal("ReportChoice accepted unknown value 'crafted_key'")
 	}
 }
 

--- a/internal/manager/persist_test.go
+++ b/internal/manager/persist_test.go
@@ -191,7 +191,7 @@ func TestListHistory(t *testing.T) {
 	mgr := New(nil, s)
 
 	// Complete two notifications to populate history.
-	for i, val := range []string{"ok", "timeout:auto"} {
+	for i, val := range []string{"ok", "timeout:restart"} {
 		cfg := testConfig(fmt.Sprintf("LH-%d", i))
 		id, _ := mgr.Submit(cfg)
 		mgr.ReportChoice(id, val)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -61,6 +61,10 @@ func testConfigJSON(heading string) []byte {
 		Message:        "Test message",
 		TimeoutSeconds: 10,
 		TimeoutValue:   "auto",
+		Buttons: []config.Button{
+			{Label: "OK", Value: "ok"},
+			{Label: "Restart", Value: "restart"},
+		},
 	}
 	data, _ := json.Marshal(cfg)
 	return data

--- a/testdata/action-chaining.json
+++ b/testdata/action-chaining.json
@@ -13,7 +13,7 @@
     { "label": "Dismiss", "value": "dismiss", "style": "secondary" }
   ],
   "result_actions": {
-    "reconnect": "url:https://github.com/TsekNet/hermes",
-    "wiki": "url:https://github.com/TsekNet/hermes#readme"
+    "reconnect": "uri:https://github.com/TsekNet/hermes",
+    "wiki": "uri:https://github.com/TsekNet/hermes#readme"
   }
 }

--- a/testdata/escalation-restart.json
+++ b/testdata/escalation-restart.json
@@ -40,6 +40,6 @@
     }
   ],
   "result_actions": {
-    "restart": "url:https://github.com/TsekNet/hermes"
+    "restart": "uri:https://github.com/TsekNet/hermes"
   }
 }

--- a/testdata/examples/README.md
+++ b/testdata/examples/README.md
@@ -78,7 +78,7 @@ Delivery is suppressed during a configured daily window (e.g. 22:00 -- 07:00).
 
 ### Action chaining
 
-Button clicks trigger follow-up actions (`cmd:` or `url:` prefixes).
+Button clicks trigger follow-up actions (`action:` or `uri:` prefixes).
 
 ![action-chaining](action-chaining.png)
 

--- a/testdata/install-with-watch.json
+++ b/testdata/install-with-watch.json
@@ -9,7 +9,7 @@
     "/var/db/receipts/com.example.security-agent.plist"
   ],
   "buttons": [
-    {"label": "Install", "value": "url:https://intranet.example.com/install-agent", "style": "primary"},
+    {"label": "Install", "value": "uri:https://intranet.example.com/install-agent", "style": "primary"},
     {"label": "Dismiss", "value": "dismiss", "style": "secondary"}
   ]
 }

--- a/testdata/quiet-hours.json
+++ b/testdata/quiet-hours.json
@@ -16,6 +16,6 @@
     { "label": "Defer 4h", "value": "defer_4h", "style": "secondary" }
   ],
   "result_actions": {
-    "update": "url:https://github.com/TsekNet/hermes"
+    "update": "uri:https://github.com/TsekNet/hermes"
   }
 }

--- a/testdata/workflow-step2-update.json
+++ b/testdata/workflow-step2-update.json
@@ -13,6 +13,6 @@
     { "label": "Defer 1h", "value": "defer_1h", "style": "secondary" }
   ],
   "result_actions": {
-    "restart": "url:https://github.com/TsekNet/hermes"
+    "restart": "uri:https://github.com/TsekNet/hermes"
   }
 }


### PR DESCRIPTION
## Summary

- Remove `cmd:` prefix entirely: shell execution from config is not permitted
- Switch URI validation from denylist to allowlist (only approved schemes pass)
- Validate `ReportChoice` values against notification config (prevents zero-click action injection)
- Fix `AdjustTokenPrivileges` silent failure on Windows (`ERROR_NOT_ALL_ASSIGNED`)
- Fix dead `TrimPrefix` code in URI extraction, remove redundant frontend branch
- Config validation rejects `cmd:` in buttons, dropdowns, and `result_actions`
- Docs reference source code for scheme/verb lists instead of hardcoding them

Ref #6

## Test plan

- [ ] `go test -race -count=1 -tags webkit2_41 ./internal/... ./cmd/...` passes (13 packages)
- [ ] `go vet -tags webkit2_41 ./...` clean
- [ ] Verify `cmd:` values are rejected in all config positions
- [ ] Verify URI allowlist: approved schemes pass, all others rejected
- [ ] Verify `ReportChoice` rejects values not in notification config