### PR TITLE
feat: Replace TCP transport with Unix domain sockets

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Cross-platform notification daemon: per-user gRPC service + Wails v2 webview UI.
 
 Read `docs/architecture.md` for the full design. Key facts for code changes:
 
-- Service model: `hermes serve` runs per-user, gRPC on `127.0.0.1:4770`. CLI and Wails UI are gRPC clients
+- Service model: `hermes serve` runs per-user, gRPC over Unix domain socket. CLI and Wails UI are gRPC clients
 - Config format: `docs/usage.md`. Subcommands, flags, exit codes also documented there
 - Platform details: `docs/platforms.md`. Build/test workflow: `docs/development.md`
 

--- a/cmd/cancel.go
+++ b/cmd/cancel.go
@@ -5,18 +5,16 @@ import (
 	"fmt"
 
 	"github.com/TsekNet/hermes/internal/client"
-	"github.com/TsekNet/hermes/internal/server"
 	"github.com/spf13/cobra"
 )
 
 func cancelCmd() *cobra.Command {
-	var port int
 	cmd := &cobra.Command{
 		Use:   "cancel <notification-id>",
 		Short: "Cancel an active notification",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(_ *cobra.Command, args []string) error {
-			c, err := client.Dial(port)
+			c, err := client.Dial()
 			if err != nil {
 				return fmt.Errorf("connect to service: %w", err)
 			}
@@ -34,6 +32,5 @@ func cancelCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().IntVar(&port, "port", server.DefaultPort, "service gRPC port")
 	return cmd
 }

--- a/cmd/inbox.go
+++ b/cmd/inbox.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/TsekNet/hermes/internal/app"
 	"github.com/TsekNet/hermes/internal/client"
-	"github.com/TsekNet/hermes/internal/server"
 	"github.com/TsekNet/hermes/internal/store"
 	"github.com/google/deck"
 	"github.com/spf13/cobra"
@@ -20,7 +19,6 @@ import (
 
 func inboxCmd() *cobra.Command {
 	var (
-		port   int
 		asJSON bool
 		dbPath string
 	)
@@ -34,19 +32,18 @@ action (uri: opens the URI, action: runs the built-in verb).`,
   hermes inbox --json`,
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if asJSON {
-				return printInboxJSON(port, dbPath)
+				return printInboxJSON(dbPath)
 			}
-			return runInboxUI(port, dbPath)
+			return runInboxUI(dbPath)
 		},
 	}
-	cmd.Flags().IntVar(&port, "port", server.DefaultPort, "service gRPC port")
 	cmd.Flags().BoolVar(&asJSON, "json", false, "print history as JSON to stdout")
 	cmd.Flags().StringVar(&dbPath, "db", "", "read directly from bolt DB (skip service)")
 	return cmd
 }
 
-func printInboxJSON(port int, dbPath string) error {
-	entries, err := fetchHistory(port, dbPath)
+func printInboxJSON(dbPath string) error {
+	entries, err := fetchHistory(dbPath)
 	if err != nil {
 		return err
 	}
@@ -55,7 +52,7 @@ func printInboxJSON(port int, dbPath string) error {
 	return enc.Encode(entries)
 }
 
-func runInboxUI(port int, dbPath string) error {
+func runInboxUI(dbPath string) error {
 	var inboxApp *app.InboxApp
 
 	if dbPath != "" {
@@ -65,7 +62,7 @@ func runInboxUI(port int, dbPath string) error {
 		}
 		inboxApp = app.NewInboxLocal(s)
 	} else {
-		c, err := client.Dial(port)
+		c, err := client.Dial()
 		if err != nil {
 			deck.Warningf("service not reachable, falling back to direct DB read")
 			s, err := store.OpenReadOnly("")
@@ -93,11 +90,11 @@ func runInboxUI(port int, dbPath string) error {
 	})
 }
 
-func fetchHistory(port int, dbPath string) ([]app.InboxEntry, error) {
+func fetchHistory(dbPath string) ([]app.InboxEntry, error) {
 	if dbPath != "" {
 		return fetchHistoryFromDB(dbPath)
 	}
-	entries, err := fetchHistoryFromService(port)
+	entries, err := fetchHistoryFromService()
 	if err != nil {
 		deck.Warningf("service not reachable (%v), falling back to direct DB read", err)
 		return fetchHistoryFromDB("")
@@ -125,8 +122,8 @@ func fetchHistoryFromDB(dbPath string) ([]app.InboxEntry, error) {
 	return out, nil
 }
 
-func fetchHistoryFromService(port int) ([]app.InboxEntry, error) {
-	c, err := client.Dial(port)
+func fetchHistoryFromService() ([]app.InboxEntry, error) {
+	c, err := client.Dial()
 	if err != nil {
 		return nil, fmt.Errorf("connect to service: %w", err)
 	}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -6,17 +6,15 @@ import (
 	"time"
 
 	"github.com/TsekNet/hermes/internal/client"
-	"github.com/TsekNet/hermes/internal/server"
 	"github.com/spf13/cobra"
 )
 
 func listCmd() *cobra.Command {
-	var port int
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List active notifications",
 		RunE: func(_ *cobra.Command, _ []string) error {
-			c, err := client.Dial(port)
+			c, err := client.Dial()
 			if err != nil {
 				return fmt.Errorf("connect to service: %w", err)
 			}
@@ -43,6 +41,5 @@ func listCmd() *cobra.Command {
 			return nil
 		},
 	}
-	cmd.Flags().IntVar(&port, "port", server.DefaultPort, "service gRPC port")
 	return cmd
 }

--- a/cmd/motd.go
+++ b/cmd/motd.go
@@ -29,7 +29,7 @@ func runMotd(dbPath string) error {
 		return nil
 	}
 
-	entries, err := fetchHistory(0, dbPath)
+	entries, err := fetchHistory(dbPath)
 	if err != nil {
 		return nil
 	}

--- a/cmd/notify.go
+++ b/cmd/notify.go
@@ -5,16 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"strconv"
 
 	"github.com/TsekNet/hermes/internal/client"
 	"github.com/TsekNet/hermes/internal/config"
-	"github.com/TsekNet/hermes/internal/server"
 	"github.com/google/deck"
 	"github.com/spf13/cobra"
 )
-
-var flagNotifyPort int
 
 func notifyCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -37,7 +33,6 @@ Config can be a file path (JSON or YAML), inline JSON string, or piped via stdin
 		Args:          cobra.MaximumNArgs(1),
 		RunE:          runNotify,
 	}
-	cmd.Flags().IntVar(&flagNotifyPort, "port", server.DefaultPort, "service gRPC port")
 	return cmd
 }
 
@@ -55,7 +50,7 @@ func runNotify(_ *cobra.Command, args []string) error {
 		return broadcastNotify(cfg, args)
 	}
 
-	c, err := client.Dial(flagNotifyPort)
+	c, err := client.Dial()
 	if err != nil {
 		if tryEnqueue(cfg, err) {
 			return nil
@@ -64,7 +59,7 @@ func runNotify(_ *cobra.Command, args []string) error {
 	}
 	defer c.Close()
 
-	deck.Infof("notification: mode=notify heading=%q port=%d buttons=%d", cfg.Heading, flagNotifyPort, len(cfg.Buttons))
+	deck.Infof("notification: mode=notify heading=%q buttons=%d", cfg.Heading, len(cfg.Buttons))
 	result, err := c.Notify(context.Background(), cfg)
 	if err != nil {
 		if tryEnqueue(cfg, err) {
@@ -90,9 +85,6 @@ func broadcastNotify(cfg *config.NotificationConfig, args []string) error {
 	}
 
 	notifyArgs := []string{"notify"}
-	if flagNotifyPort != server.DefaultPort {
-		notifyArgs = append(notifyArgs, "--port", strconv.Itoa(flagNotifyPort))
-	}
 
 	switch {
 	case flagConfig != "":

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,7 +17,6 @@ import (
 	"github.com/TsekNet/hermes/internal/config"
 	"github.com/TsekNet/hermes/internal/dnd"
 	"github.com/TsekNet/hermes/internal/exitcodes"
-	"github.com/TsekNet/hermes/internal/server"
 	"github.com/TsekNet/hermes/internal/store"
 	"github.com/google/deck"
 	"github.com/spf13/cobra"
@@ -36,7 +35,6 @@ var (
 	flagConfig         string
 	flagLocale         string
 	flagNotificationID string
-	flagServicePort    int
 )
 
 // Execute is the single entry point called from main.
@@ -79,11 +77,9 @@ Use '--config' or '--local' to render directly without the service.`,
 	f.StringVar(&flagConfig, "config", "", "config file or inline JSON/YAML")
 	f.StringVar(&flagLocale, "locale", "", "override locale for localized notifications (e.g. ja, de, es)")
 
-	// Hidden flags — set by the service when launching UI subprocesses.
+	// Hidden flag — set by the service when launching UI subprocesses.
 	f.StringVar(&flagNotificationID, "notification-id", "", "notification ID (set by service)")
-	f.IntVar(&flagServicePort, "service-port", server.DefaultPort, "gRPC service port (set by service)")
 	f.MarkHidden("notification-id")
-	f.MarkHidden("service-port")
 
 	root.AddCommand(demoCmd())
 	root.AddCommand(versionCmd())
@@ -103,7 +99,7 @@ Use '--config' or '--local' to render directly without the service.`,
 func runRoot(_ *cobra.Command, args []string) error {
 	// Mode 1: UI subprocess launched by the service (gRPC).
 	if flagNotificationID != "" {
-		return runServiceUI(flagNotificationID, flagServicePort)
+		return runServiceUI(flagNotificationID)
 	}
 
 	// Resolve config from --config flag, positional arg, or stdin.
@@ -154,7 +150,7 @@ func runDemo() error {
 // sendToService sends a config to the gRPC service and blocks for the result.
 // If the service is unreachable, it falls back to the offline queue.
 func sendToService(cfg *config.NotificationConfig) error {
-	c, err := client.DialDefault()
+	c, err := client.Dial()
 	if err != nil {
 		if tryEnqueue(cfg, err) {
 			return nil
@@ -210,8 +206,8 @@ func printResultAndExit(r *client.NotifyResult) {
 
 // runServiceUI is Mode 1: the service spawned this process with a notification ID.
 // It fetches config from the service via gRPC, renders the UI, and reports back.
-func runServiceUI(notifID string, port int) error {
-	c, err := client.Dial(port)
+func runServiceUI(notifID string) error {
+	c, err := client.Dial()
 	if err != nil {
 		return fmt.Errorf("connect to service: %w", err)
 	}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -14,6 +14,7 @@ import (
 	"github.com/TsekNet/hermes/internal/manager"
 	"github.com/TsekNet/hermes/internal/ratelimit"
 	"github.com/TsekNet/hermes/internal/server"
+	"github.com/TsekNet/hermes/internal/socket"
 	"github.com/TsekNet/hermes/internal/store"
 	"github.com/TsekNet/hermes/internal/tray"
 	"github.com/google/deck"
@@ -22,7 +23,6 @@ import (
 )
 
 var (
-	flagPort   int
 	flagDB     string
 	flagNoTray bool
 )
@@ -41,13 +41,21 @@ Deferral state is persisted to a local bolt database so notifications survive
 service restarts.`,
 		RunE: runServe,
 	}
-	cmd.Flags().IntVar(&flagPort, "port", server.DefaultPort, "gRPC listen port")
 	cmd.Flags().StringVar(&flagDB, "db", "", "bolt database path (default: platform-specific)")
 	cmd.Flags().BoolVar(&flagNoTray, "no-tray", false, "disable system tray icon")
 	return cmd
 }
 
 func runServe(_ *cobra.Command, _ []string) error {
+	sockPath := socket.Path()
+
+	lis, err := socket.Listen(sockPath)
+	if err != nil {
+		return err
+	}
+	defer lis.Close()
+	defer socket.Cleanup(sockPath)
+
 	s, err := store.Open(flagDB)
 	if err != nil {
 		return fmt.Errorf("open store: %w", err)
@@ -78,7 +86,7 @@ func runServe(_ *cobra.Command, _ []string) error {
 	interceptors = append(interceptors, auth.UnaryInterceptor(token))
 	interceptors = append(interceptors, rl.UnaryInterceptor())
 
-	srv := server.New(mgr, flagPort, interceptors...)
+	srv := server.New(mgr, interceptors...)
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
@@ -88,16 +96,11 @@ func runServe(_ *cobra.Command, _ []string) error {
 	useTray := !flagNoTray && tray.ShouldEnable(runtime.GOOS, os.Getenv)
 
 	if useTray {
-		deck.Infof("hermes service starting on port %d with tray icon (per-user daemon, pid %d)", flagPort, os.Getpid())
+		deck.Infof("hermes service starting on %s with tray icon (per-user daemon, pid %d)", sockPath, os.Getpid())
 
-		// gRPC server runs in a goroutine; main goroutine owns the tray
-		// event loop (required by macOS Cocoa for the menu bar).
 		errCh := make(chan error, 1)
-		go func() { errCh <- srv.Serve() }()
+		go func() { errCh <- srv.Serve(lis) }()
 
-		// trayReady is closed by tray.Run's onReady callback. The
-		// shutdown goroutine waits on it so tray.Quit() is never
-		// called before systray.Run() has initialized.
 		trayReady := make(chan struct{})
 		go func() {
 			<-trayReady
@@ -117,18 +120,16 @@ func runServe(_ *cobra.Command, _ []string) error {
 		tray.Run(tray.Config{
 			Count: mgr.ActiveCount,
 			Stop:  srv.Stop,
-			Port:  flagPort,
 			Ready: trayReady,
 		})
 
 		return nil
 	}
 
-	// No tray: original behavior, gRPC blocks the main goroutine.
 	if flagNoTray {
-		deck.Infof("hermes service starting on port %d (tray disabled, per-user daemon, pid %d)", flagPort, os.Getpid())
+		deck.Infof("hermes service starting on %s (tray disabled, per-user daemon, pid %d)", sockPath, os.Getpid())
 	} else {
-		deck.Infof("hermes service starting on port %d (no display server, tray skipped, per-user daemon, pid %d)", flagPort, os.Getpid())
+		deck.Infof("hermes service starting on %s (no display server, tray skipped, per-user daemon, pid %d)", sockPath, os.Getpid())
 	}
 
 	go func() {
@@ -137,7 +138,7 @@ func runServe(_ *cobra.Command, _ []string) error {
 		srv.Stop()
 	}()
 
-	return srv.Serve()
+	return srv.Serve(lis)
 }
 
 // drainDelay is the breathing room between queued notifications so the
@@ -257,7 +258,7 @@ func reshowNotification(n *manager.Notification) {
 		return
 	}
 
-	args := []string{"--notification-id", n.ID, "--service-port", fmt.Sprintf("%d", flagPort)}
+	args := []string{"--notification-id", n.ID}
 	if err := launchSubprocess(selfPath, args); err != nil {
 		deck.Errorf("notification: reshow id=%s error=%q", n.ID, err)
 		return

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -3,158 +3,58 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"net"
 	"os"
-	"os/exec"
-	"runtime"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/TsekNet/hermes/internal/client"
-	"github.com/TsekNet/hermes/internal/server"
+	"github.com/TsekNet/hermes/internal/socket"
 	"github.com/google/deck"
 	"github.com/spf13/cobra"
 )
 
 func stopCmd() *cobra.Command {
-	var port int
 	cmd := &cobra.Command{
 		Use:   "stop",
 		Short: "Stop the running hermes service daemon",
-		Long: `Sends a graceful Shutdown RPC to the hermes daemon. Falls back to
-process-level signals if the gRPC call fails.`,
+		Long:  `Sends a graceful Shutdown RPC to the hermes daemon via its Unix domain socket.`,
 		RunE: func(_ *cobra.Command, _ []string) error {
-			return runStop(port)
+			return runStop()
 		},
 	}
-	cmd.Flags().IntVar(&port, "port", server.DefaultPort, "gRPC port to find the daemon on")
 	return cmd
 }
 
-func runStop(port int) error {
-	if port < 1 || port > 65535 {
-		return fmt.Errorf("invalid port: %d (must be 1-65535)", port)
+func runStop() error {
+	sockPath := socket.Path()
+	if !socket.IsRunning(sockPath) {
+		return fmt.Errorf("no hermes daemon found (socket %s)", sockPath)
 	}
 
-	if stopped := tryGracefulShutdown(port); stopped {
-		return nil
-	}
-
-	pid, err := findListenerPID(port)
+	c, err := client.Dial()
 	if err != nil {
-		return fmt.Errorf("no hermes daemon found on port %d: %w", port, err)
-	}
-
-	deck.Infof("found hermes daemon pid %d on port %d", pid, port)
-
-	if err := killProcess(pid); err != nil {
-		return fmt.Errorf("stop pid %d: %w", pid, err)
-	}
-
-	if waitForExit(port, 5*time.Second) {
-		fmt.Fprintf(os.Stderr, "hermes daemon (pid %d) stopped\n", pid)
-		return nil
-	}
-	return fmt.Errorf("daemon pid %d did not exit within 5s", pid)
-}
-
-func tryGracefulShutdown(port int) bool {
-	c, err := client.Dial(port)
-	if err != nil {
-		return false
+		return fmt.Errorf("connect to daemon: %w", err)
 	}
 	defer c.Close()
 
-	deck.Infof("sending Shutdown RPC to port %d", port)
+	deck.Infof("sending Shutdown RPC via %s", sockPath)
 	if err := c.Shutdown(context.Background()); err != nil {
-		deck.Warningf("Shutdown RPC failed: %v, falling back to process kill", err)
-		return false
+		return fmt.Errorf("shutdown RPC: %w", err)
 	}
-	if waitForExit(port, 5*time.Second) {
-		fmt.Fprintf(os.Stderr, "hermes daemon stopped (graceful shutdown)\n")
-		return true
+
+	if waitForSocketRemoval(sockPath, 5*time.Second) {
+		fmt.Fprintf(os.Stderr, "hermes daemon stopped\n")
+		return nil
 	}
-	deck.Warningf("daemon did not exit after Shutdown RPC, falling back to process kill")
-	return false
+	return fmt.Errorf("daemon did not exit within 5s")
 }
 
-func waitForExit(port int, timeout time.Duration) bool {
+func waitForSocketRemoval(path string, timeout time.Duration) bool {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 200*time.Millisecond)
-		if err != nil {
+		if !socket.IsRunning(path) {
 			return true
 		}
-		conn.Close()
 		time.Sleep(250 * time.Millisecond)
 	}
 	return false
-}
-
-func findListenerPID(port int) (int, error) {
-	switch runtime.GOOS {
-	case "windows":
-		return findListenerWindows(port)
-	default:
-		return findListenerUnix(port)
-	}
-}
-
-func findListenerUnix(port int) (int, error) {
-	// lsof is available on macOS and most Linux distros.
-	out, err := exec.Command("lsof", "-ti", fmt.Sprintf("tcp:%d", port)).Output()
-	if err != nil {
-		// Fallback: try ss (Linux).
-		out, err = exec.Command("ss", "-tlnp", fmt.Sprintf("sport = :%d", port)).Output()
-		if err != nil {
-			return 0, fmt.Errorf("cannot find listener: lsof and ss both failed")
-		}
-		return parseSS(string(out))
-	}
-	s := strings.TrimSpace(string(out))
-	lines := strings.Split(s, "\n")
-	return strconv.Atoi(strings.TrimSpace(lines[0]))
-}
-
-func parseSS(output string) (int, error) {
-	for _, line := range strings.Split(output, "\n") {
-		if idx := strings.Index(line, "pid="); idx >= 0 {
-			rest := line[idx+4:]
-			if comma := strings.IndexByte(rest, ','); comma > 0 {
-				rest = rest[:comma]
-			}
-			return strconv.Atoi(strings.TrimSpace(rest))
-		}
-	}
-	return 0, fmt.Errorf("no pid found in ss output")
-}
-
-func findListenerWindows(port int) (int, error) {
-	out, err := exec.Command("netstat", "-ano", "-p", "TCP").Output()
-	if err != nil {
-		return 0, fmt.Errorf("netstat: %w", err)
-	}
-	target := fmt.Sprintf(":%d", port)
-	for _, line := range strings.Split(string(out), "\n") {
-		fields := strings.Fields(line)
-		if len(fields) < 5 {
-			continue
-		}
-		if strings.HasSuffix(fields[1], target) && strings.EqualFold(fields[3], "LISTENING") {
-			return strconv.Atoi(fields[4])
-		}
-	}
-	return 0, fmt.Errorf("no listener on port %d", port)
-}
-
-func killProcess(pid int) error {
-	if runtime.GOOS == "windows" {
-		return exec.Command("taskkill", "/F", "/PID", strconv.Itoa(pid)).Run()
-	}
-	p, err := os.FindProcess(pid)
-	if err != nil {
-		return err
-	}
-	return p.Signal(os.Interrupt)
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,7 +30,7 @@ sequenceDiagram
     participant UI as Webview (user session)
 
     Service->>Tray: Show icon + pending count
-    Script->>Service: gRPC Notify on localhost:4770
+    Script->>Service: gRPC Notify via Unix domain socket
     Service->>UI: Launch webview directly (same session)
     UI->>Service: gRPC ReportChoice
     Service->>Script: Notify RPC returns result
@@ -266,7 +266,15 @@ The `internal/` packages import only Go stdlib and each other — no Wails depen
 
 ## gRPC transport
 
-All IPC uses gRPC over TCP on `127.0.0.1:4770` (configurable via `--port`). No TLS — localhost only. The service binds to the loopback interface exclusively.
+All IPC uses gRPC over a Unix domain socket (`AF_UNIX`). No TLS, no TCP ports. The socket path is platform-specific:
+
+| Platform | Socket path |
+|----------|-------------|
+| Windows  | `%LOCALAPPDATA%\hermes\hermes.sock` |
+| macOS    | `~/.hermes/hermes.sock` |
+| Linux    | `$XDG_RUNTIME_DIR/hermes/hermes.sock` (or `~/.hermes/hermes.sock`) |
+
+UDS is invisible to port scanners and eliminates port collisions in multi-user environments. The socket file is created with `0600` permissions on Unix (Windows `AF_UNIX` does not enforce filesystem permissions, so the auth token provides defense in depth).
 
 ### Authentication
 
@@ -358,7 +366,7 @@ Then enable: `systemctl --user enable --now hermes.service`
 
 ### Multi-user machines
 
-Each user runs their own `hermes serve` on the default port. Only one instance can bind port 4770 per user (loopback). For concurrent multi-user sessions on the same machine, configure different ports via `--port`.
+Each user runs their own `hermes serve` with a per-user Unix domain socket. Socket paths are derived from user-specific directories (`$XDG_RUNTIME_DIR`, `%LOCALAPPDATA%`), so multiple users on the same machine never collide. No port configuration needed.
 
 ---
 

--- a/docs/broadcast.md
+++ b/docs/broadcast.md
@@ -25,7 +25,7 @@ Hermes reuses the same session launch machinery as `hermes install`:
 | Linux | `/run/user/<uid>` scan + `SysProcAttr.Credential` |
 | macOS | `/Users` scan + `SysProcAttr.Credential` |
 
-Each child process runs in the user's context with access to the per-user auth token (`session.token`) and daemon on `127.0.0.1:4770`.
+Each child process runs in the user's context with access to the per-user auth token (`session.token`) and daemon socket.
 
 ---
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -372,7 +372,6 @@ The second notification is held in `waiting_on_dependency` state until the first
 | `--config <path or json>` | root | config file or inline JSON/YAML — routes to service |
 | `--local` | root | Render locally in current session (skip service) |
 | `--locale <code>` | root | Override locale for localized notifications (e.g. `ja`, `de`) |
-| `--port <int>` | serve, notify, list, cancel, stop, inbox | gRPC port (default: 4770) |
 | `--no-tray` | serve | Disable the system tray icon (default: auto-detect display server) |
 | `--db <path>` | serve, inbox, motd | Bolt database path (default: platform-specific, see [Architecture](architecture.md#persistence)) |
 | `--json` | inbox | Print history as JSON instead of opening the UI |

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -10,10 +10,9 @@ import (
 
 	"github.com/TsekNet/hermes/internal/auth"
 	"github.com/TsekNet/hermes/internal/config"
-	"github.com/TsekNet/hermes/internal/server"
+	"github.com/TsekNet/hermes/internal/socket"
 	pb "github.com/TsekNet/hermes/proto"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 // Client wraps a gRPC connection to the hermes service.
@@ -22,24 +21,23 @@ type Client struct {
 	svc  pb.HermesServiceClient
 }
 
-// Dial connects to the hermes gRPC service on localhost.
+// Dial connects to the hermes gRPC service via Unix domain socket.
 // It auto-loads the session token from disk for authentication.
-func Dial(port int) (*Client, error) {
-	addr := fmt.Sprintf("127.0.0.1:%d", port)
-	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
-	if token, err := auth.LoadToken(); err == nil && token != "" {
-		opts = append(opts, grpc.WithPerRPCCredentials(&auth.PerRPCCredentials{Token: token}))
-	}
-	conn, err := grpc.NewClient(addr, opts...)
-	if err != nil {
-		return nil, fmt.Errorf("grpc dial %s: %w", addr, err)
-	}
-	return &Client{conn: conn, svc: pb.NewHermesServiceClient(conn)}, nil
+func Dial() (*Client, error) {
+	return DialPath(socket.Path())
 }
 
-// DialDefault connects using the default port.
-func DialDefault() (*Client, error) {
-	return Dial(server.DefaultPort)
+// DialPath connects to the hermes gRPC service at the given socket path.
+func DialPath(sockPath string) (*Client, error) {
+	var extraOpts []grpc.DialOption
+	if token, err := auth.LoadToken(); err == nil && token != "" {
+		extraOpts = append(extraOpts, grpc.WithPerRPCCredentials(&auth.PerRPCCredentials{Token: token}))
+	}
+	conn, err := socket.Dial(sockPath, extraOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{conn: conn, svc: pb.NewHermesServiceClient(conn)}, nil
 }
 
 // Close closes the underlying connection.

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"path/filepath"
 	"testing"
@@ -14,22 +13,19 @@ import (
 	"github.com/TsekNet/hermes/internal/store"
 )
 
-// startTestService starts a gRPC server on a random port and returns the port.
-func startTestService(t *testing.T) int {
+func startTestService(t *testing.T) string {
 	t.Helper()
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	sock := filepath.Join(t.TempDir(), "hermes.sock")
+	mgr := manager.New(func(n *manager.Notification) {}, nil)
+	srv := server.New(mgr)
+
+	lis, err := net.Listen("unix", sock)
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	port := lis.Addr().(*net.TCPAddr).Port
-	lis.Close()
-
-	mgr := manager.New(func(n *manager.Notification) {}, nil)
-	srv := server.New(mgr, port)
-	go func() { srv.Serve() }()
+	go func() { srv.Serve(lis) }()
 	t.Cleanup(srv.Stop)
-	time.Sleep(100 * time.Millisecond)
-	return port
+	return sock
 }
 
 func testCfg(id string) *config.NotificationConfig {
@@ -47,10 +43,10 @@ func testCfg(id string) *config.NotificationConfig {
 
 func TestDialAndPing(t *testing.T) {
 	t.Parallel()
-	port := startTestService(t)
-	c, err := Dial(port)
+	sock := startTestService(t)
+	c, err := DialPath(sock)
 	if err != nil {
-		t.Fatalf("Dial: %v", err)
+		t.Fatalf("DialPath: %v", err)
 	}
 	defer c.Close()
 
@@ -61,12 +57,11 @@ func TestDialAndPing(t *testing.T) {
 
 func TestNotifyAndReportChoice(t *testing.T) {
 	t.Parallel()
-	port := startTestService(t)
+	sock := startTestService(t)
 
-	// Submit in background via one client.
-	c1, err := Dial(port)
+	c1, err := DialPath(sock)
 	if err != nil {
-		t.Fatalf("Dial: %v", err)
+		t.Fatalf("DialPath: %v", err)
 	}
 	defer c1.Close()
 
@@ -81,8 +76,7 @@ func TestNotifyAndReportChoice(t *testing.T) {
 	}()
 	time.Sleep(200 * time.Millisecond)
 
-	// Report choice via a second client.
-	c2, _ := Dial(port)
+	c2, _ := DialPath(sock)
 	defer c2.Close()
 	ok, err := c2.ReportChoice(context.Background(), "notify-test-1", "ok")
 	if err != nil {
@@ -107,21 +101,19 @@ func TestNotifyAndReportChoice(t *testing.T) {
 
 func TestListAndCancel(t *testing.T) {
 	t.Parallel()
-	port := startTestService(t)
+	sock := startTestService(t)
 
-	// Submit a notification in background.
-	c1, _ := Dial(port)
+	c1, _ := DialPath(sock)
 	defer c1.Close()
 
 	go func() {
-		c1.Notify(context.Background(), testCfg(fmt.Sprintf("lc-%d", port)))
+		c1.Notify(context.Background(), testCfg("lc-1"))
 	}()
 	time.Sleep(200 * time.Millisecond)
 
-	c2, _ := Dial(port)
+	c2, _ := DialPath(sock)
 	defer c2.Close()
 
-	// List should find it.
 	entries, err := c2.List(context.Background())
 	if err != nil {
 		t.Fatalf("List: %v", err)
@@ -130,8 +122,7 @@ func TestListAndCancel(t *testing.T) {
 		t.Fatalf("expected >= 1 entry, got %d", len(entries))
 	}
 
-	// Cancel it.
-	found, err := c2.Cancel(context.Background(), fmt.Sprintf("lc-%d", port))
+	found, err := c2.Cancel(context.Background(), "lc-1")
 	if err != nil {
 		t.Fatalf("Cancel: %v", err)
 	}
@@ -142,18 +133,18 @@ func TestListAndCancel(t *testing.T) {
 
 func TestGetUIConfig(t *testing.T) {
 	t.Parallel()
-	port := startTestService(t)
+	sock := startTestService(t)
 
-	c1, _ := Dial(port)
+	c1, _ := DialPath(sock)
 	defer c1.Close()
 
-	id := fmt.Sprintf("ui-%d", port)
+	id := "ui-test"
 	go func() {
 		c1.Notify(context.Background(), testCfg(id))
 	}()
 	time.Sleep(200 * time.Millisecond)
 
-	c2, _ := Dial(port)
+	c2, _ := DialPath(sock)
 	defer c2.Close()
 
 	cfg, deferAllowed, err := c2.GetUIConfig(context.Background(), id)
@@ -171,42 +162,40 @@ func TestGetUIConfig(t *testing.T) {
 func TestListHistory(t *testing.T) {
 	t.Parallel()
 
-	s, err := store.Open(filepath.Join(t.TempDir(), "history.db"))
+	tmpDir := t.TempDir()
+	s, err := store.Open(filepath.Join(tmpDir, "history.db"))
 	if err != nil {
 		t.Fatalf("store.Open: %v", err)
 	}
 	t.Cleanup(func() { s.Close() })
 
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	sock := filepath.Join(tmpDir, "hermes.sock")
+	mgr := manager.New(func(n *manager.Notification) {}, s)
+	srv := server.New(mgr)
+
+	lis, err := net.Listen("unix", sock)
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	port := lis.Addr().(*net.TCPAddr).Port
-	lis.Close()
-
-	mgr := manager.New(func(n *manager.Notification) {}, s)
-	srv := server.New(mgr, port)
-	go func() { srv.Serve() }()
+	go func() { srv.Serve(lis) }()
 	t.Cleanup(srv.Stop)
-	time.Sleep(100 * time.Millisecond)
 
-	c1, err := Dial(port)
+	c1, err := DialPath(sock)
 	if err != nil {
-		t.Fatalf("Dial: %v", err)
+		t.Fatalf("DialPath: %v", err)
 	}
 	defer c1.Close()
 
-	// Submit and complete a notification.
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		c1.Notify(context.Background(), testCfg(fmt.Sprintf("hist-%d", port)))
+		c1.Notify(context.Background(), testCfg("hist-1"))
 	}()
 	time.Sleep(200 * time.Millisecond)
 
-	c2, _ := Dial(port)
+	c2, _ := DialPath(sock)
 	defer c2.Close()
-	c2.ReportChoice(context.Background(), fmt.Sprintf("hist-%d", port), "ok")
+	c2.ReportChoice(context.Background(), "hist-1", "ok")
 
 	select {
 	case <-done:
@@ -232,11 +221,9 @@ func TestListHistory(t *testing.T) {
 	}
 }
 
-func TestDialDefault(t *testing.T) {
+func TestDial_NoServer(t *testing.T) {
 	t.Parallel()
-	// DialDefault tries the default port — just confirm it doesn't panic.
-	// Connection may fail (no server), that's fine.
-	c, err := DialDefault()
+	c, err := Dial()
 	if err == nil {
 		c.Close()
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,40 +15,31 @@ import (
 	"google.golang.org/grpc"
 )
 
-// DefaultPort is the default TCP port for the gRPC service.
-const DefaultPort = 4770
-
 // Server wraps the gRPC server and notification manager.
 type Server struct {
 	pb.UnimplementedHermesServiceServer
-	mgr    *manager.Manager
-	grpc   *grpc.Server
-	port   int
+	mgr  *manager.Manager
+	grpc *grpc.Server
 }
 
-// New creates a Server bound to the given manager and port.
+// New creates a Server. Call Serve with a pre-opened listener to start.
 // Interceptors are applied in order: first in the list runs outermost.
-func New(mgr *manager.Manager, port int, interceptors ...grpc.UnaryServerInterceptor) *Server {
+func New(mgr *manager.Manager, interceptors ...grpc.UnaryServerInterceptor) *Server {
 	opts := []grpc.ServerOption{grpc.MaxRecvMsgSize(128 * 1024)}
 	if len(interceptors) > 0 {
 		opts = append(opts, grpc.ChainUnaryInterceptor(interceptors...))
 	}
 	s := &Server{
 		mgr:  mgr,
-		port: port,
 		grpc: grpc.NewServer(opts...),
 	}
 	pb.RegisterHermesServiceServer(s.grpc, s)
 	return s
 }
 
-// Serve starts listening on localhost:<port>. Blocks until Stop is called.
-func (s *Server) Serve() error {
-	lis, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", s.port))
-	if err != nil {
-		return fmt.Errorf("listen: %w", err)
-	}
-	deck.Infof("gRPC server listening on %s", lis.Addr())
+// Serve starts the gRPC server on lis. Blocks until Stop is called.
+func (s *Server) Serve(lis net.Listener) error {
+	deck.Infof("gRPC server listening on %s:%s", lis.Addr().Network(), lis.Addr())
 	return s.grpc.Serve(lis)
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3,7 +3,6 @@ package server
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net"
 	"path/filepath"
 	"testing"
@@ -11,42 +10,32 @@ import (
 
 	"github.com/TsekNet/hermes/internal/config"
 	"github.com/TsekNet/hermes/internal/manager"
+	"github.com/TsekNet/hermes/internal/socket"
 	"github.com/TsekNet/hermes/internal/store"
 	pb "github.com/TsekNet/hermes/proto"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-// startTestServer starts a gRPC server on a random port and returns a client.
+// startTestServer starts a gRPC server on a UDS in a temp dir and returns a client.
 func startTestServer(t *testing.T) (pb.HermesServiceClient, *Server) {
 	t.Helper()
 
-	mgr := manager.New(func(n *manager.Notification) {
-		// no-op reshow for tests
-	}, nil)
+	mgr := manager.New(func(n *manager.Notification) {}, nil)
+	sock := filepath.Join(t.TempDir(), "hermes.sock")
+	srv := New(mgr)
 
-	// Find a free port.
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	lis, err := net.Listen("unix", sock)
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	port := lis.Addr().(*net.TCPAddr).Port
-	lis.Close()
-
-	srv := New(mgr, port)
-
-	go func() {
-		if err := srv.Serve(); err != nil {
-			// Server stopped, expected during cleanup.
-		}
-	}()
+	go func() { srv.Serve(lis) }()
 	t.Cleanup(srv.Stop)
 
-	// Wait for server to be ready.
-	time.Sleep(100 * time.Millisecond)
-
-	addr := fmt.Sprintf("127.0.0.1:%d", port)
-	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(
+		socket.DialTarget(sock),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
@@ -215,28 +204,28 @@ func TestList(t *testing.T) {
 func TestListHistory_AfterCompletion(t *testing.T) {
 	t.Parallel()
 
-	s, err := store.Open(filepath.Join(t.TempDir(), "history.db"))
+	tmpDir := t.TempDir()
+	s, err := store.Open(filepath.Join(tmpDir, "history.db"))
 	if err != nil {
 		t.Fatalf("store.Open: %v", err)
 	}
 	t.Cleanup(func() { s.Close() })
 
 	mgr := manager.New(func(n *manager.Notification) {}, s)
+	sock := filepath.Join(tmpDir, "hermes.sock")
+	srv := New(mgr)
 
-	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	lis, err := net.Listen("unix", sock)
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	port := lis.Addr().(*net.TCPAddr).Port
-	lis.Close()
-
-	srv := New(mgr, port)
-	go func() { srv.Serve() }()
+	go func() { srv.Serve(lis) }()
 	t.Cleanup(srv.Stop)
-	time.Sleep(100 * time.Millisecond)
 
-	addr := fmt.Sprintf("127.0.0.1:%d", port)
-	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(
+		socket.DialTarget(sock),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}

--- a/internal/socket/addrinuse_unix.go
+++ b/internal/socket/addrinuse_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package socket
+
+import (
+	"errors"
+	"syscall"
+)
+
+func isAddrInUse(err error) bool {
+	return errors.Is(err, syscall.EADDRINUSE)
+}

--- a/internal/socket/addrinuse_windows.go
+++ b/internal/socket/addrinuse_windows.go
@@ -1,0 +1,15 @@
+//go:build windows
+
+package socket
+
+import (
+	"errors"
+	"syscall"
+)
+
+// WSAEADDRINUSE is the Windows Sockets error for "address already in use".
+const wsaeaddrinuse = syscall.Errno(10048)
+
+func isAddrInUse(err error) bool {
+	return errors.Is(err, wsaeaddrinuse)
+}

--- a/internal/socket/socket.go
+++ b/internal/socket/socket.go
@@ -1,0 +1,120 @@
+// Package socket provides Unix domain socket transport for the hermes gRPC service.
+// UDS replaces TCP for all IPC: invisible to port scanners, no port collisions
+// in multi-user environments, and OS-level access control via file permissions.
+package socket
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+const sockName = "hermes.sock"
+
+// Path returns the platform-specific Unix domain socket path.
+// macOS uses ~/.hermes/ (not ~/Library/Application Support/hermes/) to stay
+// within the 104-byte sun_path limit. The auth token path in internal/auth
+// uses the longer Library path because it has no such constraint.
+func Path() string {
+	switch runtime.GOOS {
+	case "windows":
+		if d := os.Getenv("LOCALAPPDATA"); d != "" {
+			return filepath.Join(d, "hermes", sockName)
+		}
+		home, _ := os.UserHomeDir()
+		return filepath.Join(home, "AppData", "Local", "hermes", sockName)
+	case "darwin":
+		home, _ := os.UserHomeDir()
+		return filepath.Join(home, ".hermes", sockName)
+	default:
+		if dir := os.Getenv("XDG_RUNTIME_DIR"); dir != "" {
+			return filepath.Join(dir, "hermes", sockName)
+		}
+		home, _ := os.UserHomeDir()
+		return filepath.Join(home, ".hermes", sockName)
+	}
+}
+
+// Listen creates a Unix domain socket listener at the given path.
+// It handles stale sockets (leftover from a crash) by probing: if the
+// socket file exists but nobody is listening, it removes and retries.
+// If another daemon is actively listening, it returns an error.
+func Listen(path string) (net.Listener, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return nil, fmt.Errorf("create socket dir: %w", err)
+	}
+
+	lis, err := net.Listen("unix", path)
+	if err == nil {
+		os.Chmod(path, 0600)
+		return lis, nil
+	}
+
+	if !isAddrInUse(err) {
+		return nil, fmt.Errorf("listen unix %s: %w", path, err)
+	}
+
+	// Socket file exists. Probe to distinguish stale from live.
+	conn, dialErr := net.DialTimeout("unix", path, 500*time.Millisecond)
+	if dialErr == nil {
+		conn.Close()
+		return nil, fmt.Errorf("hermes is already running (socket %s)", path)
+	}
+
+	// Stale socket: remove and retry.
+	os.Remove(path)
+	lis, err = net.Listen("unix", path)
+	if err != nil {
+		return nil, fmt.Errorf("listen unix %s (after stale removal): %w", path, err)
+	}
+	os.Chmod(path, 0600)
+	return lis, nil
+}
+
+// Dial connects to the hermes gRPC service via Unix domain socket.
+func Dial(path string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	target := DialTarget(path)
+	defaults := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	opts = append(defaults, opts...)
+	conn, err := grpc.NewClient(target, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("grpc dial %s: %w", path, err)
+	}
+	return conn, nil
+}
+
+// DialTarget returns the gRPC target string for a Unix domain socket path.
+// Unix absolute paths: "unix://" + "/abs/path" = "unix:///abs/path".
+// Windows paths (C:\...): "unix:" + path (no authority, no leading slash).
+func DialTarget(path string) string {
+	if len(path) > 0 && path[0] == '/' {
+		return "unix://" + path
+	}
+	return "unix:" + path
+}
+
+// Cleanup removes the socket file. Called on service shutdown.
+func Cleanup(path string) {
+	os.Remove(path)
+}
+
+// IsRunning reports whether a hermes daemon is actively listening on the
+// given socket path. Returns false if the socket doesn't exist, is stale,
+// or the dial times out.
+func IsRunning(path string) bool {
+	if _, err := os.Stat(path); err != nil {
+		return false
+	}
+	conn, err := net.DialTimeout("unix", path, 500*time.Millisecond)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}

--- a/internal/socket/socket_test.go
+++ b/internal/socket/socket_test.go
@@ -1,0 +1,285 @@
+package socket
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+func TestPath_NotEmpty(t *testing.T) {
+	t.Parallel()
+	p := Path()
+	if p == "" {
+		t.Fatal("Path() returned empty string")
+	}
+}
+
+func TestPath_UnderSunPathLimit(t *testing.T) {
+	t.Parallel()
+	p := Path()
+	// sun_path limits: Linux 108, macOS 104, Windows ~260.
+	limit := 104
+	if runtime.GOOS == "windows" {
+		limit = 260
+	}
+	if len(p) >= limit {
+		t.Errorf("Path() = %q (%d bytes), exceeds sun_path limit of %d", p, len(p), limit)
+	}
+}
+
+func TestPath_ContainsHermes(t *testing.T) {
+	t.Parallel()
+	p := Path()
+	if !strings.Contains(p, "hermes") {
+		t.Errorf("Path() = %q, expected to contain 'hermes'", p)
+	}
+}
+
+func TestPath_Deterministic(t *testing.T) {
+	t.Parallel()
+	if Path() != Path() {
+		t.Error("Path() is not deterministic")
+	}
+}
+
+func TestListen_CreatesSocket(t *testing.T) {
+	t.Parallel()
+	sock := filepath.Join(t.TempDir(), "hermes.sock")
+	lis, err := Listen(sock)
+	if err != nil {
+		t.Fatalf("Listen(%q): %v", sock, err)
+	}
+	defer lis.Close()
+
+	if _, err := os.Stat(sock); err != nil {
+		t.Errorf("socket file not created: %v", err)
+	}
+}
+
+func TestListen_CreatesParentDir(t *testing.T) {
+	t.Parallel()
+	sock := filepath.Join(t.TempDir(), "nested", "deep", "hermes.sock")
+	lis, err := Listen(sock)
+	if err != nil {
+		t.Fatalf("Listen(%q): %v", sock, err)
+	}
+	defer lis.Close()
+
+	info, err := os.Stat(filepath.Dir(sock))
+	if err != nil {
+		t.Fatalf("parent dir not created: %v", err)
+	}
+	if runtime.GOOS != "windows" {
+		if perm := info.Mode().Perm(); perm != 0700 {
+			t.Errorf("parent dir permissions = %o, want 0700", perm)
+		}
+	}
+}
+
+func TestListen_RemovesStaleSocket(t *testing.T) {
+	t.Parallel()
+	sock := filepath.Join(t.TempDir(), "hermes.sock")
+
+	// Create a stale socket file (no listener).
+	if err := os.WriteFile(sock, []byte("stale"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	lis, err := Listen(sock)
+	if err != nil {
+		t.Fatalf("Listen should recover from stale socket: %v", err)
+	}
+	defer lis.Close()
+}
+
+func TestListen_RejectsLiveSocket(t *testing.T) {
+	t.Parallel()
+	sock := filepath.Join(t.TempDir(), "hermes.sock")
+
+	first, err := Listen(sock)
+	if err != nil {
+		t.Fatalf("first Listen: %v", err)
+	}
+	defer first.Close()
+
+	_, err = Listen(sock)
+	if err == nil {
+		t.Fatal("second Listen should fail when first is still alive")
+	}
+	if !strings.Contains(err.Error(), "already running") {
+		t.Errorf("error = %q, want it to mention 'already running'", err)
+	}
+}
+
+func TestDial_ConnectsToListener(t *testing.T) {
+	t.Parallel()
+	sock := filepath.Join(t.TempDir(), "hermes.sock")
+
+	lis, err := Listen(sock)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer lis.Close()
+
+	// Start a minimal gRPC server to accept the connection.
+	srv := grpc.NewServer()
+	go srv.Serve(lis)
+	defer srv.Stop()
+
+	conn, err := Dial(sock)
+	if err != nil {
+		t.Fatalf("Dial(%q): %v", sock, err)
+	}
+	defer conn.Close()
+}
+
+func TestDial_FailsWithNoListener(t *testing.T) {
+	t.Parallel()
+	sock := filepath.Join(t.TempDir(), "hermes.sock")
+
+	conn, err := grpc.NewClient(
+		"unix://"+sock,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("NewClient: %v", err)
+	}
+	defer conn.Close()
+
+	// Force a connection attempt: the socket doesn't exist, so any RPC
+	// context should fail. We just verify grpc.NewClient itself succeeds
+	// (lazy connect) but actual connectivity fails.
+	ctx, cancel := context.WithTimeout(context.Background(), 1)
+	defer cancel()
+	conn.Connect()
+	<-ctx.Done()
+	if conn.GetState().String() == "READY" {
+		t.Error("connection should not be READY with no listener")
+	}
+}
+
+func TestCleanup_RemovesSocket(t *testing.T) {
+	t.Parallel()
+	sock := filepath.Join(t.TempDir(), "hermes.sock")
+
+	lis, err := Listen(sock)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	lis.Close()
+
+	Cleanup(sock)
+	if _, err := os.Stat(sock); !os.IsNotExist(err) {
+		t.Errorf("Cleanup should remove socket file, got stat error: %v", err)
+	}
+}
+
+func TestCleanup_NoErrorOnMissing(t *testing.T) {
+	t.Parallel()
+	Cleanup(filepath.Join(t.TempDir(), "nonexistent.sock"))
+}
+
+func TestGRPCRoundTrip(t *testing.T) {
+	t.Parallel()
+	sock := filepath.Join(t.TempDir(), "hermes.sock")
+
+	lis, err := Listen(sock)
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer lis.Close()
+
+	srv := grpc.NewServer()
+	go srv.Serve(lis)
+	defer srv.Stop()
+
+	conn, err := Dial(sock)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+
+	// Verify the connection reaches READY state.
+	ctx, cancel := context.WithTimeout(context.Background(), 5e9)
+	defer cancel()
+	conn.Connect()
+	for conn.GetState().String() != "READY" {
+		if !conn.WaitForStateChange(ctx, conn.GetState()) {
+			t.Fatal("connection did not reach READY state")
+		}
+	}
+}
+
+func TestDialTarget(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"simple", "/tmp/hermes.sock", "unix:///tmp/hermes.sock"},
+		{"nested", "/run/user/1000/hermes/hermes.sock", "unix:///run/user/1000/hermes/hermes.sock"},
+	}
+	if runtime.GOOS == "windows" {
+		tests = append(tests, struct {
+			name string
+			path string
+			want string
+		}{"windows", `C:\Users\test\AppData\Local\hermes\hermes.sock`, `unix:C:\Users\test\AppData\Local\hermes\hermes.sock`})
+	} else {
+		tests = append(tests, struct {
+			name string
+			path string
+			want string
+		}{"relative", "hermes.sock", "unix:hermes.sock"})
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := DialTarget(tt.path); got != tt.want {
+				t.Errorf("DialTarget(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsRunning(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no socket", func(t *testing.T) {
+		t.Parallel()
+		sock := filepath.Join(t.TempDir(), "hermes.sock")
+		if IsRunning(sock) {
+			t.Error("IsRunning should return false when no socket exists")
+		}
+	})
+
+	t.Run("stale socket", func(t *testing.T) {
+		t.Parallel()
+		sock := filepath.Join(t.TempDir(), "hermes.sock")
+		os.WriteFile(sock, []byte("stale"), 0600)
+		if IsRunning(sock) {
+			t.Error("IsRunning should return false for stale socket")
+		}
+	})
+
+	t.Run("live socket", func(t *testing.T) {
+		t.Parallel()
+		sock := filepath.Join(t.TempDir(), "hermes.sock")
+		lis, err := net.Listen("unix", sock)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer lis.Close()
+		if !IsRunning(sock) {
+			t.Error("IsRunning should return true for live socket")
+		}
+	})
+}

--- a/internal/tray/run.go
+++ b/internal/tray/run.go
@@ -19,7 +19,6 @@ type StopFunc func()
 type Config struct {
 	Count CountFunc
 	Stop  StopFunc
-	Port  int
 	Ready chan<- struct{} // closed when the tray is initialized; nil = no signal
 	done  chan struct{}
 }
@@ -54,7 +53,7 @@ func onReady(cfg Config) {
 	for {
 		select {
 		case <-mInbox.ClickedCh:
-			launchInbox(cfg.Port)
+			launchInbox()
 		case <-mQuit.ClickedCh:
 			deck.Info("tray: quit requested by user")
 			if cfg.Stop != nil {
@@ -84,14 +83,14 @@ func pollCount(countFn CountFunc, mInbox *systray.MenuItem, done <-chan struct{}
 // launchInbox starts the inbox UI as a detached subprocess.
 // Uses os.Executable to avoid PATH injection (red team: attacker-controlled
 // PATH could plant a malicious "hermes" binary).
-func launchInbox(port int) {
+func launchInbox() {
 	selfPath, err := os.Executable()
 	if err != nil {
 		deck.Errorf("tray: cannot determine executable path: %v", err)
 		return
 	}
 
-	args := InboxArgs(port)
+	args := InboxArgs()
 	cmd := exec.Command(selfPath, args...)
 	detachProcess(cmd)
 
@@ -99,7 +98,7 @@ func launchInbox(port int) {
 		deck.Errorf("tray: launch inbox: %v", err)
 		return
 	}
-	deck.Infof("tray: launched inbox (pid %d, port %d)", cmd.Process.Pid, port)
+	deck.Infof("tray: launched inbox (pid %d)", cmd.Process.Pid)
 }
 
 // detachProcess is implemented in detach_unix.go / detach_windows.go.

--- a/internal/tray/tray.go
+++ b/internal/tray/tray.go
@@ -59,8 +59,7 @@ func ShouldEnable(goos string, envLookup func(string) string) bool {
 	}
 }
 
-// InboxArgs returns the command-line arguments for launching the inbox
-// subprocess. The caller provides the port to connect to the service.
-func InboxArgs(port int) []string {
-	return []string{"inbox", "--port", fmt.Sprintf("%d", port)}
+// InboxArgs returns the command-line arguments for launching the inbox subprocess.
+func InboxArgs() []string {
+	return []string{"inbox"}
 }

--- a/internal/tray/tray_test.go
+++ b/internal/tray/tray_test.go
@@ -95,31 +95,15 @@ func TestShouldEnable(t *testing.T) {
 
 func TestInboxArgs(t *testing.T) {
 	t.Parallel()
-
-	tests := []struct {
-		name     string
-		selfPath string
-		port     int
-		want     []string
-	}{
-		{"default port", "/usr/local/bin/hermes", 4770, []string{"inbox", "--port", "4770"}},
-		{"custom port", "/opt/hermes/hermes", 5000, []string{"inbox", "--port", "5000"}},
-		{"windows path", `C:\Program Files\Hermes\hermes.exe`, 4770, []string{"inbox", "--port", "4770"}},
+	got := InboxArgs()
+	want := []string{"inbox"}
+	if len(got) != len(want) {
+		t.Fatalf("InboxArgs() len = %d, want %d", len(got), len(want))
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			got := InboxArgs(tt.port)
-			if len(got) != len(tt.want) {
-				t.Fatalf("InboxArgs(%d) len = %d, want %d", tt.port, len(got), len(tt.want))
-			}
-			for i := range got {
-				if got[i] != tt.want[i] {
-					t.Errorf("InboxArgs(%d)[%d] = %q, want %q", tt.port, i, got[i], tt.want[i])
-				}
-			}
-		})
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("InboxArgs()[%d] = %q, want %q", i, got[i], want[i])
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- New `internal/socket` package: platform-specific UDS paths, stale socket recovery, 0600 permissions
- Server accepts pre-opened `net.Listener`: `socket.Listen()` before `store.Open()` makes the listen call the atomic singleton guard (no TOCTOU)
- Remove all `--port` / `--service-port` flags, simplify `cmd/stop.go` (PID-hunting replaced by gRPC Shutdown RPC)
- Updated architecture, usage, and broadcast docs

## Test plan

| Platform | Test | Result |
|---|---|---|
| Linux | Unit tests (16 packages, -race) | Pass |
| Linux | serve/notify/list/stop integration | Pass |
| Linux | Second serve atomic rejection | Pass |
| Linux | Stale socket recovery (SIGKILL) | Pass |
| Windows | serve + socket creation | Pass |
| Windows | Second serve rejection | Pass |
| Windows | Notification webview renders in user session | Pass |
| Windows | stop + socket cleanup | Pass |

Ref #10

Generated with [Claude Code](https://claude.ai/code)