### PR TITLE
Add app launcher shortcuts for notification history

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,13 +108,18 @@ jobs:
           VERSION="${GITHUB_REF#refs/tags/v}"
           ARCH=amd64
           PKG=hermes_${VERSION}
-          mkdir -p "${PKG}/usr/local/bin" "${PKG}/usr/lib/systemd/user"
+          mkdir -p "${PKG}/usr/local/bin" "${PKG}/usr/lib/systemd/user" \
+            "${PKG}/usr/share/applications" "${PKG}/usr/share/icons/hicolor/256x256/apps"
           cp -f hermes "${PKG}/usr/local/bin/"
           chmod 755 "${PKG}/usr/local/bin/hermes"
           printf '%s\n' '[Unit]' 'Description=Hermes notification service' '' \
             '[Service]' 'ExecStart=/usr/local/bin/hermes serve' 'Restart=on-failure' '' \
             '[Install]' 'WantedBy=default.target' > "${PKG}/usr/lib/systemd/user/hermes.service"
           chmod 644 "${PKG}/usr/lib/systemd/user/hermes.service"
+          cp ../build/linux/hermes-notifications.desktop "${PKG}/usr/share/applications/"
+          chmod 644 "${PKG}/usr/share/applications/hermes-notifications.desktop"
+          cp ../build/appicon.png "${PKG}/usr/share/icons/hicolor/256x256/apps/hermes.png"
+          chmod 644 "${PKG}/usr/share/icons/hicolor/256x256/apps/hermes.png"
           mkdir -p "${PKG}/DEBIAN"
           printf 'Package: hermes\nVersion: %s\nArchitecture: %s\nMaintainer: Hermes <admin@tseknet.com>\nDescription: Cross-platform notification daemon (per-user gRPC + Wails UI)\n' "$VERSION" "$ARCH" > "${PKG}/DEBIAN/control"
           printf '%s\n' '#!/bin/sh' 'set -e' \
@@ -131,6 +136,8 @@ jobs:
             'if [ "$1" = "purge" ] || [ "$1" = "remove" ]; then' \
             '  /usr/local/bin/hermes uninstall 2>/dev/null || true' \
             '  rm -f /usr/lib/systemd/user/hermes.service' \
+            '  rm -f /usr/share/applications/hermes-notifications.desktop' \
+            '  rm -f /usr/share/icons/hicolor/256x256/apps/hermes.png' \
             '  for home_dir in /home/*; do' \
             '    rm -f "$home_dir/.config/systemd/user/hermes.service" 2>/dev/null || true' \
             '  done' \
@@ -150,6 +157,8 @@ jobs:
     needs: build
     runs-on: macos-latest
     steps:
+      - uses: actions/checkout@v4
+
       - name: Download macOS artifacts
         uses: actions/download-artifact@v4
         with:
@@ -168,6 +177,48 @@ jobs:
           mkdir -p "$PKGROOT/usr/local/bin"
           cp hermes "$PKGROOT/usr/local/bin/hermes"
           chmod 755 "$PKGROOT/usr/local/bin/hermes"
+
+          # Build .app bundle for Spotlight discoverability
+          APP="$PKGROOT/Applications/Hermes Notifications.app"
+          mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
+          printf '#!/bin/sh\nexec /usr/local/bin/hermes inbox "$@"\n' > "$APP/Contents/MacOS/launcher"
+          chmod 755 "$APP/Contents/MacOS/launcher"
+
+          # Generate .icns from source PNG
+          ICONSET="$(mktemp -d)/AppIcon.iconset"
+          mkdir -p "$ICONSET"
+          for size in 16 32 128 256 512; do
+            sips -z $size $size build/appicon.png --out "$ICONSET/icon_${size}x${size}.png" >/dev/null
+            double=$((size * 2))
+            sips -z $double $double build/appicon.png --out "$ICONSET/icon_${size}x${size}@2x.png" >/dev/null
+          done
+          iconutil -c icns "$ICONSET" -o "$APP/Contents/Resources/AppIcon.icns"
+
+          cat > "$APP/Contents/Info.plist" << 'PLIST'
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0">
+          <dict>
+            <key>CFBundleIdentifier</key>
+            <string>com.tseknet.hermes.notifications</string>
+            <key>CFBundleName</key>
+            <string>Hermes Notifications</string>
+            <key>CFBundleDisplayName</key>
+            <string>Hermes Notifications</string>
+            <key>CFBundleExecutable</key>
+            <string>launcher</string>
+            <key>CFBundleIconFile</key>
+            <string>AppIcon</string>
+            <key>CFBundlePackageType</key>
+            <string>APPL</string>
+            <key>CFBundleVersion</key>
+            <string>1.0</string>
+            <key>LSUIElement</key>
+            <false/>
+          </dict>
+          </plist>
+          PLIST
+
           SCRIPTS="$(mktemp -d)"
           printf '%s\n' '#!/bin/sh' \
             '/usr/local/bin/hermes stop 2>/dev/null || true' \

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ The service tracks deferrals per notification, persisted to disk. When the user 
 | **Dependencies** | Sequential workflows: notification B waits for notification A to complete. |
 | **Broadcast** | Run as SYSTEM/root, auto-delivers to all active user sessions. No wrapper scripts needed. |
 | **System tray icon** | Persistent notification-area icon with pending count and quick inbox access. Auto-detected on desktop sessions, skipped on headless. |
+| **App launcher shortcut** | "Hermes Notifications" in Start Menu / Spotlight / GNOME Activities. Searchable by name and "notifications" keyword. |
 
 ## Why web-based
 

--- a/build/linux/hermes-notifications.desktop
+++ b/build/linux/hermes-notifications.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Hermes Notifications
+GenericName=Notification History
+Comment=View past notifications and their responses
+Exec=/usr/local/bin/hermes inbox
+Icon=hermes
+Terminal=false
+Categories=Utility;
+Keywords=notifications;alerts;history;messages;
+StartupNotify=false

--- a/build/windows/msi/hermes.wxs
+++ b/build/windows/msi/hermes.wxs
@@ -30,6 +30,20 @@
       </Directory>
     </StandardDirectory>
 
+    <StandardDirectory Id="ProgramMenuFolder">
+      <Directory Id="HermesMenuFolder" Name="Hermes">
+        <Component Id="HermesStartMenu" Guid="F6A7B8C9-D012-3456-EF01-789012CDEF01">
+          <Shortcut Id="InboxShortcut" Name="Hermes Notifications"
+                    Description="View notification history"
+                    Target="[#HermesExeFile]" Arguments="inbox"
+                    WorkingDirectory="HermesDir" Icon="HermesIcon" IconIndex="0" />
+          <RemoveFolder Id="RemoveHermesMenuFolder" On="uninstall" />
+          <RegistryValue Root="HKCU" Key="Software\TsekNet\Hermes"
+                         Name="StartMenu" Type="integer" Value="1" KeyPath="yes" />
+        </Component>
+      </Directory>
+    </StandardDirectory>
+
     <!-- Deferred custom actions: property ID must match custom action ID -->
     <SetProperty Id="StopHermes" Value="&quot;[#HermesExeFile]&quot; stop"
       Before="StopHermes" Sequence="execute" />
@@ -56,6 +70,7 @@
       <ComponentRef Id="HermesExe" />
       <ComponentRef Id="HermesAutostart" />
       <ComponentRef Id="CleanupDir" />
+      <ComponentRef Id="HermesStartMenu" />
     </Feature>
   </Package>
 </Wix>

--- a/build/windows/msi/hermes.wxs
+++ b/build/windows/msi/hermes.wxs
@@ -23,7 +23,7 @@
         <Component Id="HermesAutostart" Guid="D4E5F6A7-B890-1234-CDEF-567890ABCDEF">
           <RegistryValue Root="HKLM" Key="SOFTWARE\Microsoft\Windows\CurrentVersion\Run" Name="Hermes" Value="&quot;[HermesDir]hermes.exe&quot; serve" Type="string" KeyPath="yes" />
         </Component>
-        <Component Id="CleanupDir" Guid="E5F6A7B8-C901-2345-DEF0-678901BCDEF0">
+<Component Id="CleanupDir" Guid="E5F6A7B8-C901-2345-DEF0-678901BCDEF0">
           <RemoveFolder Id="RemoveHermesDir" On="uninstall" />
           <RegistryValue Root="HKLM" Key="SOFTWARE\TsekNet\Hermes" Name="Cleanup" Value="1" Type="integer" KeyPath="yes" />
         </Component>
@@ -35,7 +35,8 @@
         <Component Id="HermesStartMenu" Guid="F6A7B8C9-D012-3456-EF01-789012CDEF01">
           <Shortcut Id="InboxShortcut" Name="Hermes Notifications"
                     Description="View notification history"
-                    Target="[#HermesExeFile]" Arguments="inbox"
+                    Target="[SystemFolder]conhost.exe"
+                    Arguments="--headless &quot;[#HermesExeFile]&quot; inbox"
                     WorkingDirectory="HermesDir" Icon="HermesIcon" IconIndex="0" />
           <RemoveFolder Id="RemoveHermesMenuFolder" On="uninstall" />
           <RegistryValue Root="HKCU" Key="Software\TsekNet\Hermes"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -256,6 +256,8 @@ hermes/
 │   └── main.js                    Countdown, dropdowns, Wails bindings
 │
 ├── build/                         Wails build metadata (icons, manifest)
+│   ├── linux/hermes-notifications.desktop  App launcher entry (GNOME/KDE)
+│   └── windows/msi/hermes.wxs             MSI installer (Start Menu shortcut)
 ├── assets/                        Source artwork (logo, screenshots)
 └── docs/                          Documentation
 ```

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -18,11 +18,11 @@ Platform-specific behavior: webview engines and deployment. See **[Architecture]
 
 The `hermes serve` daemon runs **per-user** in the desktop session. Run the installer; it handles placement, autostart, and MOTD. No additional setup.
 
-| Platform | Install | Autostart |
-|----------|---------|-----------|
-| Windows | **hermes.msi** | HKLM Run key at logon. `hermes install` also launches the daemon immediately in all active user sessions via Win32 `CreateProcessAsUser`. |
-| Linux | `sudo dpkg -i hermes.deb` | systemd user unit + profile.d. `hermes install` also launches the daemon immediately for all logged-in users via `SysProcAttr.Credential`. |
-| macOS | **hermes.pkg** (universal, Intel + Apple Silicon) | LaunchAgent in `/Library/LaunchAgents`; profile.d + zprofile snippet via postinstall. `hermes install` also launches the daemon immediately for all active users. |
+| Platform | Install | Autostart | App launcher |
+|----------|---------|-----------|-------------|
+| Windows | **hermes.msi** | HKLM Run key at logon. `hermes install` also launches the daemon immediately in all active user sessions via Win32 `CreateProcessAsUser`. | Start Menu shortcut "Hermes Notifications" (via `conhost --headless` to suppress console window) |
+| Linux | `sudo dpkg -i hermes.deb` | systemd user unit + profile.d. `hermes install` also launches the daemon immediately for all logged-in users via `SysProcAttr.Credential`. | .desktop file with `Keywords=notifications;alerts;history;` |
+| macOS | **hermes.pkg** (universal, Intel + Apple Silicon) | LaunchAgent in `/Library/LaunchAgents`; profile.d + zprofile snippet via postinstall. `hermes install` also launches the daemon immediately for all active users. | "Hermes Notifications.app" in /Applications (shell launcher to `hermes inbox`) |
 
 **Silent / MDM install**
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -54,6 +54,8 @@ Platform installers create a **Hermes Notifications** shortcut so users can find
 | macOS | /Applications/Hermes Notifications.app | Spotlight: "hermes", "notifications" |
 | Linux | GNOME Activities / KDE krunner | "hermes", "notifications", "alerts", "history" |
 
+On Windows, the shortcut uses `conhost --headless` to suppress the console window that would otherwise appear because the binary is built with `-windowsconsole` for CLI compatibility.
+
 ---
 
 ## Local mode

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -44,6 +44,16 @@ hermes inbox --db my.db   # Read directly from a bolt DB file (skip service)
 
 The inbox connects to the running service via gRPC. If the service is unreachable, it falls back to reading the bolt database directly. History is auto-pruned on service startup: records older than 30 days or exceeding 50 entries are removed.
 
+### App launcher shortcut
+
+Platform installers create a **Hermes Notifications** shortcut so users can find the inbox without knowing the CLI:
+
+| Platform | Location | Search keywords |
+|---|---|---|
+| Windows | Start Menu > Hermes > Hermes Notifications | "hermes", "notifications" |
+| macOS | /Applications/Hermes Notifications.app | Spotlight: "hermes", "notifications" |
+| Linux | GNOME Activities / KDE krunner | "hermes", "notifications", "alerts", "history" |
+
 ---
 
 ## Local mode


### PR DESCRIPTION
## Summary
- Adds **Hermes Notifications** Start Menu shortcut via WiX MSI (Windows)
- Adds .app bundle in /Applications for Spotlight discoverability (macOS)
- Adds .desktop file with Keywords for GNOME/KDE launcher search (Linux)
- All shortcuts launch hermes inbox to view notification history

Ref #12

## Test plan
- [ ] Windows: verify Start Menu shows Hermes Notifications after MSI install
- [ ] macOS: verify Spotlight finds Hermes Notifications after .pkg install
- [ ] Linux: verify .desktop file appears in app launcher after .deb install
- [ ] All: clicking shortcut opens notification history webview

Generated with [Claude Code](https://claude.com/claude-code)