### PR TITLE
Harden input validation and file permissions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @TsekNet

--- a/cmd/motd.go
+++ b/cmd/motd.go
@@ -68,9 +68,10 @@ func isSSHSession() bool {
 func sanitize(s string) string {
 	var b strings.Builder
 	for _, r := range s {
-		if r >= 0x20 && r != 0x7f {
-			b.WriteRune(r)
+		if r < 0x20 || r == 0x7f || (r >= 0x80 && r <= 0x9f) {
+			continue
 		}
+		b.WriteRune(r)
 	}
 	return b.String()
 }

--- a/cmd/notify.go
+++ b/cmd/notify.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/TsekNet/hermes/internal/client"
 	"github.com/TsekNet/hermes/internal/config"
@@ -96,7 +97,7 @@ func broadcastNotify(cfg *config.NotificationConfig, args []string) error {
 		if err != nil {
 			return err
 		}
-		defer os.Remove(f)
+		defer os.RemoveAll(filepath.Dir(f))
 		notifyArgs = append(notifyArgs, "--config", f)
 	}
 
@@ -110,18 +111,15 @@ func writeTempConfig(cfg *config.NotificationConfig) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("marshal config for broadcast: %w", err)
 	}
-	f, err := os.CreateTemp("", "hermes-broadcast-*.json")
+	dir, err := os.MkdirTemp("", "hermes-broadcast-*")
 	if err != nil {
-		return "", fmt.Errorf("create temp config: %w", err)
+		return "", fmt.Errorf("create temp dir: %w", err)
 	}
-	if _, err := f.Write(data); err != nil {
-		f.Close()
-		os.Remove(f.Name())
+	os.Chmod(dir, 0711)
+	path := filepath.Join(dir, "config.json")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		os.RemoveAll(dir)
 		return "", fmt.Errorf("write temp config: %w", err)
 	}
-	f.Close()
-	// Make readable by all users so child processes in other sessions
-	// (launched via CreateProcessAsUser / setuid) can read the config.
-	os.Chmod(f.Name(), 0644)
-	return f.Name(), nil
+	return path, nil
 }

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,150 +1,35 @@
 # Security
 
-This document describes Hermes's security model, the threats it defends
-against, and the boundaries where it relies on OS-level guarantees.
-
 ## Reporting Vulnerabilities
 
 Use [GitHub private vulnerability reporting](https://github.com/TsekNet/hermes/security/advisories/new)
 to disclose security issues. Do not file public issues for vulnerabilities.
 
-## Architecture
+## Security Model
 
-Hermes runs as a per-user daemon communicating over a Unix domain socket.
-No network listeners are created. The gRPC transport is `insecure` because
-traffic never leaves the machine: the UDS provides OS-level isolation
-equivalent to a loopback-only TCP socket with file permission enforcement.
+Hermes is a per-user daemon. The trust boundary is the OS user account:
+any process running as the same user has equivalent access to the daemon,
+its database, and its socket. This is by design.
 
-| Component | Trust boundary | Access control |
-|---|---|---|
-| gRPC daemon (`hermes serve`) | Per-user UDS | Socket file `0600`, parent dir `0700` |
-| Session token | Per-user file | Token file `0600`, parent dir `0700` |
-| Wails webview (notification UI) | Embedded content only | No remote content loaded |
-| Broadcast mode (SYSTEM/root) | Cross-session | Drops to target user's UID/GID via `CreateProcessAsUser` (Windows) or `syscall.Credential` (Unix) |
-| bbolt database | Per-user file | DB file `0600`, parent dir `0700` |
+For the full architecture, transport, authentication, rate limiting, and
+capacity controls, see [Architecture](architecture.md#grpc-transport).
 
-## Authentication
+For input validation rules (config fields, action prefixes, URI schemes,
+image constraints, watch paths), see [Usage](usage.md#config-format).
 
-The daemon generates a 32-byte cryptographically random token
-(`crypto/rand`) on startup, stored at a platform-specific path with `0600`
-permissions. Every gRPC call must present this token as `authorization`
-metadata. Comparison uses `crypto/subtle.ConstantTimeCompare` to prevent
-timing side-channels.
+For broadcast and privilege drop behavior, see
+[Broadcast](broadcast.md).
 
-Any process running as the same user that can read the token file has full
-access to the daemon. This is by design: the daemon serves a single user,
-and same-user access is equivalent to the user acting directly.
+## Design Decisions
 
-## Input Validation
-
-### Config payloads
-
-| Control | Implementation |
+| Decision | Rationale |
 |---|---|
-| Size limit | 64 KB max (`MaxConfigSize`), enforced before parsing |
-| Format | YAML parser (`gopkg.in/yaml.v3`), size limit mitigates expansion attacks |
-| Text sanitization | `html.EscapeString` via `SanitizeText()` on all user-visible strings |
-| MOTD sanitization | Strips ASCII control chars (< 0x20), DEL (0x7F), ESC (0x1B), and C1 controls (0x80-0x9F) |
-
-### Button and action values
-
-| Prefix | Behavior | Validation |
-|---|---|---|
-| `uri:` | Opens via OS default handler | Scheme allowlist: `https`, `http`, `ms-settings`, `x-apple.systempreferences`, `slack`, `msteams`, `companyportal`, `codex` |
-| `action:` | Runs built-in verb | Verb allowlist: `reboot`, `shutdown`, `lock` |
-| `cmd:` | **Rejected** | Explicitly blocked at validation and dispatch |
-| `defer_Xh/d/m/s` | Schedules re-show | Regex-validated duration |
-| Plain value | Returned to caller | Checked against config's known values via `HasValue()` |
-
-The `cmd:` prefix is rejected at three layers: config validation, action
-dispatch, and Wails binding response handling. Shell execution from config
-input is not permitted at any point in the pipeline.
-
-### Filesystem paths
-
-Watch paths (`watch_paths`) must be absolute and clean (`filepath.IsAbs` +
-`filepath.Clean` comparison). Path traversal via `..` components is rejected.
-Maximum of 5 watch paths per notification.
-
-### Image URIs
-
-Images must be `https:` URLs or `data:image/` base64 URIs. HTTP is rejected.
-SVG data URIs are rejected to prevent script execution in the webview.
-Maximum of 5 images per notification.
-
-## Rate Limiting
-
-The gRPC `Notify` RPC is rate-limited: burst of 5, refill of 1 per second.
-The rate limiter runs after the auth interceptor, so unauthenticated
-requests are rejected before consuming rate limit tokens. A hard cap of
-10 concurrent active notifications (`MaxActiveNotifications`) prevents
-resource exhaustion.
-
-## Broadcast Mode
-
-When running as SYSTEM (Windows) or root (Unix), `hermes notify` broadcasts
-to all active user sessions. The broadcast writes a temporary config file
-to a directory with `0711` permissions and config file with `0644`
-permissions, then launches child processes as each target user.
-
-The child processes connect to each user's own daemon using their own
-session token. The broadcast parent never accesses user daemons directly.
-
-## Webview Security
-
-The Wails webview renders embedded frontend assets compiled into the binary.
-No remote content is loaded. The frontend uses `textContent` (not
-`innerHTML`) for all user-provided text, preventing XSS even if HTML
-escaping is bypassed.
-
-The `Respond()` Wails binding validates that the value is a known config
-value (`HasValue()`), a valid `uri:` with an allowed scheme, or a valid
-`action:` with an allowed verb before dispatching. Unknown values are
-rejected with a warning log.
-
-## Socket Lifecycle
-
-The daemon creates its UDS in a `0700` directory. Stale socket cleanup
-probes the existing socket: if a connection succeeds, another daemon is
-running and startup is rejected. If the probe fails, the stale socket is
-removed and a new listener is created. The brief TOCTOU window between
-remove and listen is bounded by the `0700` parent directory, which
-restricts access to same-user processes. The socket file itself is set to
-`0600` after creation.
-
-## Supply Chain
-
-| Control | Implementation |
-|---|---|
-| Go dependencies | Pinned in `go.mod` with `go.sum` integrity verification |
-| Wails CLI | Fetched at build time (`@latest`); Wails is a build tool, not a runtime dependency |
-| Config payload size | 64 KB cap prevents YAML expansion attacks |
-| gRPC message size | 128 KB cap (`grpc.MaxRecvMsgSize`) |
-
-## Platform-Specific Notes
-
-### Windows
-
-| Aspect | Detail |
-|---|---|
-| Manifest | `asInvoker` execution level, no UAC elevation requested |
-| Privilege drop | `CreateProcessAsUser` with user's session token |
-| Shutdown privilege | `SeShutdownPrivilege` enabled via standard `AdjustTokenPrivileges` API |
-| Autostart | HKLM Run key (per-machine, set by MSI installer) |
-
-### macOS
-
-| Aspect | Detail |
-|---|---|
-| Privilege drop | `syscall.Credential` with target UID/GID + `Setsid` |
-| Socket path | `~/.hermes/` (not `~/Library/Application Support/`) to stay within 104-byte `sun_path` limit |
-
-### Linux
-
-| Aspect | Detail |
-|---|---|
-| Privilege drop | `syscall.Credential` with target UID/GID + `Setsid` |
-| Socket path | `$XDG_RUNTIME_DIR/hermes/` (falls back to `~/.hermes/`) |
-| Wayland | Forces `GDK_BACKEND=x11` for window positioning. X11 does not provide input isolation between clients on the same display. |
-| Display | Cross-session launch hardcodes `DISPLAY=:0`. Multi-seat systems may route to the wrong display server. |
-
+| No TLS on the Unix domain socket | UDS traffic is kernel-mediated and never leaves the machine. File permissions (`0600` socket, `0700` parent dir) enforce access. TLS would add overhead for zero security gain. |
+| No scope differentiation on the auth token | Same-user processes can already `kill` the daemon, `rm` the socket, or write to the database. Read-only scopes would be security theater. |
+| `cmd:` prefix rejected at three layers | Config validation, action dispatch, and Wails binding response handling all independently reject `cmd:`. Shell execution from config input is not permitted. |
+| Webview renders embedded assets only | No remote content is loaded. The frontend uses `textContent` (not `innerHTML`) for all user-provided text. |
+| Broadcast temp config uses restricted directory | The temp directory is `0711` (traversable but not listable), the config file inside is `0644`. This limits exposure on multi-user systems while allowing cross-session child processes to read the config. |
+| MOTD sanitizer strips ANSI and C1 controls | Headings flow into SSH login banners. Stripping ESC (0x1B) and C1 (0x80-0x9F) prevents terminal escape injection in addition to the standard ASCII control character filter. |
+| Watch paths must be absolute and clean | `filepath.IsAbs` + `filepath.Clean` comparison prevents path traversal. The naive `..` substring check was insufficient. |
+| Wails `Respond()` validates against config | Unknown values are rejected before dispatch, preventing the webview from triggering actions not defined in the notification config. |
+| Constant-time token comparison | `crypto/subtle.ConstantTimeCompare` prevents timing side-channels on the session token. |

--- a/docs/security.md
+++ b/docs/security.md
@@ -5,31 +5,37 @@
 Use [GitHub private vulnerability reporting](https://github.com/TsekNet/hermes/security/advisories/new)
 to disclose security issues. Do not file public issues for vulnerabilities.
 
-## Security Model
+## Trust Boundary
 
-Hermes is a per-user daemon. The trust boundary is the OS user account:
-any process running as the same user has equivalent access to the daemon,
-its database, and its socket. This is by design.
+The trust boundary is the OS user account. The daemon, socket, token,
+and database are all per-user with `0600`/`0700` permissions. Any process
+running as that user has equivalent access. Cross-user access requires
+root or a privilege escalation bug in the OS.
 
-For the full architecture, transport, authentication, rate limiting, and
-capacity controls, see [Architecture](architecture.md#grpc-transport).
+## Attack Surface
 
-For input validation rules (config fields, action prefixes, URI schemes,
-image constraints, watch paths), see [Usage](usage.md#config-format).
+| Vector | What stops you | Defense in depth |
+|---|---|---|
+| **Network probe** | No TCP/UDP listeners. gRPC runs over a Unix domain socket only. Invisible to port scanners. | Socket file `0600`, parent dir `0700`. |
+| **Unauthorized IPC** | 32-byte `crypto/rand` token required on every RPC. Token file is `0600`. | `crypto/subtle.ConstantTimeCompare` prevents timing side-channels. Auth interceptor runs before rate limiter. |
+| **Notification spam** | Token-bucket rate limiter on `Notify` RPC (burst 5, refill 1/s). Hard cap of 10 concurrent active notifications. | Offline queue also deduplicates by notification ID. |
+| **Malicious config payload** | 64 KB size cap enforced before YAML parsing (mitigates expansion attacks). gRPC caps at 128 KB (`MaxRecvMsgSize`). | Required fields validated. Unknown fields ignored by YAML unmarshaler. |
+| **XSS in notification text** | `html.EscapeString` applied unconditionally to all user-visible text (heading, message, button labels). | Frontend uses `textContent`, not `innerHTML`. Even if escaping is bypassed, the rendering path is safe. |
+| **Terminal injection via MOTD** | `sanitize()` strips all ASCII controls (< 0x20), DEL (0x7F), ESC (0x1B), and C1 controls (0x80-0x9F). | MOTD output is plaintext only, no formatting sequences pass through. |
+| **Shell injection via button values** | `cmd:` prefix rejected at config validation, action dispatch, and Wails binding. Three independent layers. | `uri:` uses a scheme allowlist (not denylist). `action:` uses a verb allowlist. `Respond()` validates against `HasValue()` before dispatching. |
+| **Path traversal via watch_paths** | Must be absolute (`filepath.IsAbs`). Must be clean (`filepath.Clean` round-trip comparison). Max 5 paths. | Filesystem watcher operates read-only (inotify/kqueue/ReadDirectoryChanges). |
+| **SVG script execution in webview** | SVG data URIs explicitly rejected in image validation. | Only `https:` URLs and `data:image/` raster URIs are accepted. Max 5 images. |
+| **Temp file snooping in broadcast mode** | Config written inside a `0711` temp directory. File is `0644` (required for cross-session child reads). Directory listing blocked. | Temp directory + file cleaned up after broadcast returns. |
+| **Stale socket hijack** | Daemon probes existing socket before cleanup: live daemon detected and startup rejected. | Parent directory is `0700`, bounding the TOCTOU window to same-user processes. |
+| **Privilege escalation from broadcast** | Child processes drop to target user's UID/GID via `CreateProcessAsUser` (Windows) or `syscall.Credential` + `Setsid` (Unix). | Children connect to the user's own daemon with the user's own token. Broadcast parent never accesses user daemons directly. |
+| **Webview calling arbitrary backend functions** | `Respond()` rejects values not in the notification config (`HasValue()`), not matching a valid `uri:` scheme, or not matching a valid `action:` verb. | Webview content is embedded at compile time. No remote content loaded. |
+| **Dependency supply chain** | `go.sum` provides integrity verification for all Go dependencies. | Wails is a build-time tool, not a runtime dependency. |
 
-For broadcast and privilege drop behavior, see
-[Broadcast](broadcast.md).
+## Cross-References
 
-## Design Decisions
-
-| Decision | Rationale |
+| Topic | Location |
 |---|---|
-| No TLS on the Unix domain socket | UDS traffic is kernel-mediated and never leaves the machine. File permissions (`0600` socket, `0700` parent dir) enforce access. TLS would add overhead for zero security gain. |
-| No scope differentiation on the auth token | Same-user processes can already `kill` the daemon, `rm` the socket, or write to the database. Read-only scopes would be security theater. |
-| `cmd:` prefix rejected at three layers | Config validation, action dispatch, and Wails binding response handling all independently reject `cmd:`. Shell execution from config input is not permitted. |
-| Webview renders embedded assets only | No remote content is loaded. The frontend uses `textContent` (not `innerHTML`) for all user-provided text. |
-| Broadcast temp config uses restricted directory | The temp directory is `0711` (traversable but not listable), the config file inside is `0644`. This limits exposure on multi-user systems while allowing cross-session child processes to read the config. |
-| MOTD sanitizer strips ANSI and C1 controls | Headings flow into SSH login banners. Stripping ESC (0x1B) and C1 (0x80-0x9F) prevents terminal escape injection in addition to the standard ASCII control character filter. |
-| Watch paths must be absolute and clean | `filepath.IsAbs` + `filepath.Clean` comparison prevents path traversal. The naive `..` substring check was insufficient. |
-| Wails `Respond()` validates against config | Unknown values are rejected before dispatch, preventing the webview from triggering actions not defined in the notification config. |
-| Constant-time token comparison | `crypto/subtle.ConstantTimeCompare` prevents timing side-channels on the session token. |
+| Architecture, transport, auth, rate limiting | [Architecture](architecture.md#grpc-transport) |
+| Config fields, action prefixes, URI schemes | [Usage](usage.md#config-format) |
+| Broadcast, privilege drop, session enumeration | [Broadcast](broadcast.md) |
+| Platform-specific deployment, webview engines | [Platforms](platforms.md) |

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,150 @@
+# Security
+
+This document describes Hermes's security model, the threats it defends
+against, and the boundaries where it relies on OS-level guarantees.
+
+## Reporting Vulnerabilities
+
+Use [GitHub private vulnerability reporting](https://github.com/TsekNet/hermes/security/advisories/new)
+to disclose security issues. Do not file public issues for vulnerabilities.
+
+## Architecture
+
+Hermes runs as a per-user daemon communicating over a Unix domain socket.
+No network listeners are created. The gRPC transport is `insecure` because
+traffic never leaves the machine: the UDS provides OS-level isolation
+equivalent to a loopback-only TCP socket with file permission enforcement.
+
+| Component | Trust boundary | Access control |
+|---|---|---|
+| gRPC daemon (`hermes serve`) | Per-user UDS | Socket file `0600`, parent dir `0700` |
+| Session token | Per-user file | Token file `0600`, parent dir `0700` |
+| Wails webview (notification UI) | Embedded content only | No remote content loaded |
+| Broadcast mode (SYSTEM/root) | Cross-session | Drops to target user's UID/GID via `CreateProcessAsUser` (Windows) or `syscall.Credential` (Unix) |
+| bbolt database | Per-user file | DB file `0600`, parent dir `0700` |
+
+## Authentication
+
+The daemon generates a 32-byte cryptographically random token
+(`crypto/rand`) on startup, stored at a platform-specific path with `0600`
+permissions. Every gRPC call must present this token as `authorization`
+metadata. Comparison uses `crypto/subtle.ConstantTimeCompare` to prevent
+timing side-channels.
+
+Any process running as the same user that can read the token file has full
+access to the daemon. This is by design: the daemon serves a single user,
+and same-user access is equivalent to the user acting directly.
+
+## Input Validation
+
+### Config payloads
+
+| Control | Implementation |
+|---|---|
+| Size limit | 64 KB max (`MaxConfigSize`), enforced before parsing |
+| Format | YAML parser (`gopkg.in/yaml.v3`), size limit mitigates expansion attacks |
+| Text sanitization | `html.EscapeString` via `SanitizeText()` on all user-visible strings |
+| MOTD sanitization | Strips ASCII control chars (< 0x20), DEL (0x7F), ESC (0x1B), and C1 controls (0x80-0x9F) |
+
+### Button and action values
+
+| Prefix | Behavior | Validation |
+|---|---|---|
+| `uri:` | Opens via OS default handler | Scheme allowlist: `https`, `http`, `ms-settings`, `x-apple.systempreferences`, `slack`, `msteams`, `companyportal`, `codex` |
+| `action:` | Runs built-in verb | Verb allowlist: `reboot`, `shutdown`, `lock` |
+| `cmd:` | **Rejected** | Explicitly blocked at validation and dispatch |
+| `defer_Xh/d/m/s` | Schedules re-show | Regex-validated duration |
+| Plain value | Returned to caller | Checked against config's known values via `HasValue()` |
+
+The `cmd:` prefix is rejected at three layers: config validation, action
+dispatch, and Wails binding response handling. Shell execution from config
+input is not permitted at any point in the pipeline.
+
+### Filesystem paths
+
+Watch paths (`watch_paths`) must be absolute and clean (`filepath.IsAbs` +
+`filepath.Clean` comparison). Path traversal via `..` components is rejected.
+Maximum of 5 watch paths per notification.
+
+### Image URIs
+
+Images must be `https:` URLs or `data:image/` base64 URIs. HTTP is rejected.
+SVG data URIs are rejected to prevent script execution in the webview.
+Maximum of 5 images per notification.
+
+## Rate Limiting
+
+The gRPC `Notify` RPC is rate-limited: burst of 5, refill of 1 per second.
+The rate limiter runs after the auth interceptor, so unauthenticated
+requests are rejected before consuming rate limit tokens. A hard cap of
+10 concurrent active notifications (`MaxActiveNotifications`) prevents
+resource exhaustion.
+
+## Broadcast Mode
+
+When running as SYSTEM (Windows) or root (Unix), `hermes notify` broadcasts
+to all active user sessions. The broadcast writes a temporary config file
+to a directory with `0711` permissions and config file with `0644`
+permissions, then launches child processes as each target user.
+
+The child processes connect to each user's own daemon using their own
+session token. The broadcast parent never accesses user daemons directly.
+
+## Webview Security
+
+The Wails webview renders embedded frontend assets compiled into the binary.
+No remote content is loaded. The frontend uses `textContent` (not
+`innerHTML`) for all user-provided text, preventing XSS even if HTML
+escaping is bypassed.
+
+The `Respond()` Wails binding validates that the value is a known config
+value (`HasValue()`), a valid `uri:` with an allowed scheme, or a valid
+`action:` with an allowed verb before dispatching. Unknown values are
+rejected with a warning log.
+
+## Socket Lifecycle
+
+The daemon creates its UDS in a `0700` directory. Stale socket cleanup
+probes the existing socket: if a connection succeeds, another daemon is
+running and startup is rejected. If the probe fails, the stale socket is
+removed and a new listener is created. The brief TOCTOU window between
+remove and listen is bounded by the `0700` parent directory, which
+restricts access to same-user processes. The socket file itself is set to
+`0600` after creation.
+
+## Supply Chain
+
+| Control | Implementation |
+|---|---|
+| Go dependencies | Pinned in `go.mod` with `go.sum` integrity verification |
+| Wails CLI | Fetched at build time (`@latest`); Wails is a build tool, not a runtime dependency |
+| Config payload size | 64 KB cap prevents YAML expansion attacks |
+| gRPC message size | 128 KB cap (`grpc.MaxRecvMsgSize`) |
+
+## Platform-Specific Notes
+
+### Windows
+
+| Aspect | Detail |
+|---|---|
+| Manifest | `asInvoker` execution level, no UAC elevation requested |
+| Privilege drop | `CreateProcessAsUser` with user's session token |
+| Shutdown privilege | `SeShutdownPrivilege` enabled via standard `AdjustTokenPrivileges` API |
+| Autostart | HKLM Run key (per-machine, set by MSI installer) |
+
+### macOS
+
+| Aspect | Detail |
+|---|---|
+| Privilege drop | `syscall.Credential` with target UID/GID + `Setsid` |
+| Socket path | `~/.hermes/` (not `~/Library/Application Support/`) to stay within 104-byte `sun_path` limit |
+
+### Linux
+
+| Aspect | Detail |
+|---|---|
+| Privilege drop | `syscall.Credential` with target UID/GID + `Setsid` |
+| Socket path | `$XDG_RUNTIME_DIR/hermes/` (falls back to `~/.hermes/`) |
+| Wayland | Forces `GDK_BACKEND=x11` for window positioning. X11 does not provide input isolation between clients on the same display. |
+| Display | Cross-session launch hardcodes `DISPLAY=:0`. Multi-seat systems may route to the wrong display server. |
+

--- a/go.mod
+++ b/go.mod
@@ -46,5 +46,3 @@ require (
 	golang.org/x/text v0.34.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 )
-
-replace github.com/TsekNet/hermes => /home/dtsekhanskiy/projects/code/github/hermes

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -128,6 +128,11 @@ func (a *App) Ready() {
 
 // Respond handles the user's choice. Opens URIs, runs builtins, sends gRPC, quits.
 func (a *App) Respond(value string) {
+	if !a.cfg.HasValue(value) && !action.IsURI(value) && !action.IsBuiltin(value) {
+		deck.Warningf("respond: rejected unknown value %q", value)
+		return
+	}
+
 	if action.IsURI(value) {
 		a.openURI(value[len("uri:"):])
 		return

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -86,8 +86,7 @@ func tokenPath() string {
 }
 
 // UnaryInterceptor returns a gRPC unary server interceptor that validates
-// the session token from metadata. Read-only RPCs accept the token
-// regardless; write RPCs require the full token.
+// the session token from metadata.
 func UnaryInterceptor(token string) grpc.UnaryServerInterceptor {
 	tokenBytes := []byte(token)
 	return func(

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"html"
 	"net/url"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -375,13 +376,8 @@ func (c *NotificationConfig) SanitizeText() {
 	}
 }
 
-// safeEscape applies html.EscapeString only if the string does not already
-// contain HTML entities, preventing double-escaping on repeated calls.
 func safeEscape(s string) string {
-	if strings.Contains(s, "&amp;") || strings.Contains(s, "&lt;") || strings.Contains(s, "&gt;") || strings.Contains(s, "&#") {
-		return s
-	}
-	return html.EscapeString(s)
+	return html.EscapeString(html.UnescapeString(s))
 }
 
 // Validate checks that required fields are present and values are safe.
@@ -436,8 +432,10 @@ func (c *NotificationConfig) Validate() error {
 		errs = append(errs, fmt.Sprintf("watch_paths: %d exceeds maximum of 5", len(c.WatchPaths)))
 	}
 	for i, p := range c.WatchPaths {
-		if strings.Contains(p, "..") {
-			errs = append(errs, fmt.Sprintf("watch_paths[%d]: path traversal (..) is not allowed", i))
+		if !filepath.IsAbs(p) {
+			errs = append(errs, fmt.Sprintf("watch_paths[%d]: must be an absolute path", i))
+		} else if cleaned := filepath.Clean(p); cleaned != p {
+			errs = append(errs, fmt.Sprintf("watch_paths[%d]: path must be clean (got %q, want %q)", i, p, cleaned))
 		}
 	}
 	if c.Priority < 0 || c.Priority > 10 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -428,7 +428,8 @@ func TestValidate_WatchPaths(t *testing.T) {
 		{name: "nil", paths: nil},
 		{name: "valid paths", paths: []string{"/tmp/receipt", "/var/log/install.log"}},
 		{name: "exactly at limit", paths: []string{"/a", "/b", "/c", "/d", "/e"}},
-		{name: "path traversal blocked", paths: []string{"/tmp/../etc/passwd"}, wantErr: true, errSubstr: "path traversal"},
+		{name: "path traversal blocked", paths: []string{"/tmp/../etc/passwd"}, wantErr: true, errSubstr: "must be clean"},
+		{name: "relative path blocked", paths: []string{"tmp/receipt"}, wantErr: true, errSubstr: "must be an absolute path"},
 		{name: "too many paths", paths: make([]string, 6), wantErr: true, errSubstr: "exceeds maximum"},
 	}
 

--- a/internal/socket/socket.go
+++ b/internal/socket/socket.go
@@ -67,7 +67,8 @@ func Listen(path string) (net.Listener, error) {
 		return nil, fmt.Errorf("hermes is already running (socket %s)", path)
 	}
 
-	// Stale socket: remove and retry.
+	// Stale socket: remove and retry. The parent directory is 0700, so only
+	// same-user processes can race this window.
 	os.Remove(path)
 	lis, err = net.Listen("unix", path)
 	if err != nil {


### PR DESCRIPTION
Closes #16

## Summary

- Remove local replace directive from go.mod that breaks external builds
- Strip ANSI escape sequences (ESC, C1 controls) in MOTD sanitizer
- Broadcast temp config uses 0711 directory instead of world-readable file
- Replace safeEscape bypass-prone heuristic with unconditional unescape-then-escape
- Watch path validation uses filepath.IsAbs + filepath.Clean instead of naive string check
- Wails Respond() validates values against config before dispatching
- Remove misleading scope comment from auth interceptor
- Add .github/CODEOWNERS
- Add docs/security.md documenting the full security model

## Test plan

- [x] go vet passes
- [x] go test -race passes (16 packages)
- [ ] Verify MOTD output strips ANSI escape sequences
- [ ] Verify broadcast temp dir permissions