### PR TITLE
Add bouncing dots watch indicator

### DIFF
--- a/frontend/main.js
+++ b/frontend/main.js
@@ -372,13 +372,31 @@
 
   function initWatchStatus() {
     var el = document.getElementById("watch-status");
-    el.style.display = "block";
-    el.textContent = "Monitoring filesystem...";
+    el.style.display = "flex";
+
+    var dots = document.createElement("span");
+    dots.className = "watch-dots";
+    for (var i = 0; i < 3; i++) {
+      var dot = document.createElement("span");
+      dot.className = "watch-dot";
+      dots.appendChild(dot);
+    }
+    el.appendChild(dots);
+
+    var text = document.createElement("span");
+    text.className = "watch-text";
+    text.textContent = "Monitoring filesystem...";
+    el.appendChild(text);
 
     if (window.runtime && window.runtime.EventsOn) {
+      var resetTimer = null;
       window.runtime.EventsOn("fs:event", function(ev) {
         var basename = ev.path.split("/").pop().split("\\").pop();
-        el.textContent = ev.op + ": " + basename;
+        text.textContent = ev.op + ": " + basename;
+        if (resetTimer) clearTimeout(resetTimer);
+        resetTimer = setTimeout(function() {
+          text.textContent = "Monitoring filesystem...";
+        }, 3000);
       });
     }
   }

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -221,11 +221,40 @@ html, body {
 }
 
 .watch-status {
+  align-items: center;
+  gap: 6px;
   padding: 4px 0;
   font-size: 11px;
   color: var(--accent);
   border-top: 1px solid var(--border);
   margin-top: 4px;
+}
+
+.watch-dots {
+  display: inline-flex;
+  gap: 3px;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.watch-dot {
+  width: 4px;
+  height: 4px;
+  background: var(--accent);
+  border-radius: 50%;
+  animation: watch-bounce 1.2s ease-in-out infinite;
+}
+
+.watch-dot:nth-child(2) { animation-delay: 0.15s; }
+.watch-dot:nth-child(3) { animation-delay: 0.3s; }
+
+@keyframes watch-bounce {
+  0%, 80%, 100% { transform: translateY(0); }
+  40% { transform: translateY(-4px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .watch-dot { animation: none; }
 }
 
 /* --- Inbox --- */


### PR DESCRIPTION
## Summary

- Replace text-only watch status with three bouncing dots animation
- Dots use `var(--accent)` so they match admin-configured theme color
- File events briefly display then reset to monitoring after 3s

Ref #18

## Changes

| File | What |
| --- | --- |
| `frontend/style.css` | Bouncing dot keyframes, flex layout, `prefers-reduced-motion` fallback |
| `frontend/main.js` | `initWatchStatus()` builds dot DOM, adds fs event reset timer |

## Test plan

- [x] Existing Go tests pass (`go test -race -tags webkit2_41 ./internal/... ./cmd/...`)
- [x] Build succeeds (`wails build -skipbindings -platform linux/amd64 -tags webkit2_41`)
- [x] Visual verification: dots render with default and custom accent colors (Playwright screenshot)
- [x] Visual verification: fs event text displays correctly
- [ ] Windows visual verification (pending: ext-nv-prd-apps Teleport session expired)

## Note

Release workflow has a known eval injection at release.yml:57 (pre-existing, not introduced here). Tag v0.7.3 uses safe semver and is not exploitable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)