### PR TITLE
Expand unit test coverage across all packages

### DIFF
--- a/cmd/inbox_test.go
+++ b/cmd/inbox_test.go
@@ -1,0 +1,159 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/TsekNet/hermes/internal/config"
+	"github.com/TsekNet/hermes/internal/store"
+)
+
+func TestFetchHistoryFromDB(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns entries from store", func(t *testing.T) {
+		t.Parallel()
+		dbPath := filepath.Join(t.TempDir(), "test.db")
+		s, err := store.Open(dbPath)
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+
+		now := time.Now()
+		s.SaveHistory(&store.HistoryRecord{
+			ID:            "h-1",
+			Config:        &config.NotificationConfig{Heading: "Reboot", Message: "Please reboot"},
+			ResponseValue: "restart",
+			CreatedAt:     now.Add(-1 * time.Hour),
+			CompletedAt:   now,
+		})
+		s.SaveHistory(&store.HistoryRecord{
+			ID:            "h-2",
+			Config:        &config.NotificationConfig{Heading: "Update", Message: "Install update"},
+			ResponseValue: "ok",
+			CreatedAt:     now.Add(-2 * time.Hour),
+			CompletedAt:   now.Add(-30 * time.Minute),
+		})
+		s.Close()
+
+		entries, err := fetchHistoryFromDB(dbPath)
+		if err != nil {
+			t.Fatalf("fetchHistoryFromDB: %v", err)
+		}
+		if len(entries) != 2 {
+			t.Fatalf("expected 2 entries, got %d", len(entries))
+		}
+		if entries[0].Heading != "Reboot" {
+			t.Errorf("first entry heading = %q, want Reboot (newest first)", entries[0].Heading)
+		}
+	})
+
+	t.Run("empty database returns empty slice", func(t *testing.T) {
+		t.Parallel()
+		dbPath := filepath.Join(t.TempDir(), "empty.db")
+		s, err := store.Open(dbPath)
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+		s.Close()
+
+		entries, err := fetchHistoryFromDB(dbPath)
+		if err != nil {
+			t.Fatalf("fetchHistoryFromDB: %v", err)
+		}
+		if len(entries) != 0 {
+			t.Errorf("expected 0 entries, got %d", len(entries))
+		}
+	})
+
+	t.Run("skips records with nil config", func(t *testing.T) {
+		t.Parallel()
+		dbPath := filepath.Join(t.TempDir(), "nilcfg.db")
+		s, err := store.Open(dbPath)
+		if err != nil {
+			t.Fatalf("Open: %v", err)
+		}
+
+		now := time.Now()
+		s.SaveHistory(&store.HistoryRecord{
+			ID:          "h-ok",
+			Config:      &config.NotificationConfig{Heading: "Valid"},
+			CompletedAt: now,
+		})
+		// Manually save a record with nil config (corrupt data scenario).
+		s.SaveHistory(&store.HistoryRecord{
+			ID:          "h-nil",
+			Config:      nil,
+			CompletedAt: now.Add(-time.Hour),
+		})
+		s.Close()
+
+		entries, err := fetchHistoryFromDB(dbPath)
+		if err != nil {
+			t.Fatalf("fetchHistoryFromDB: %v", err)
+		}
+		if len(entries) != 1 {
+			t.Fatalf("expected 1 entry (nil config skipped), got %d", len(entries))
+		}
+		if entries[0].Heading != "Valid" {
+			t.Errorf("heading = %q, want Valid", entries[0].Heading)
+		}
+	})
+
+	t.Run("invalid db path returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := fetchHistoryFromDB("/nonexistent/path/hermes.db")
+		if err == nil {
+			t.Fatal("expected error for invalid DB path")
+		}
+	})
+}
+
+func TestPrintInboxJSON(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "inbox.db")
+	s, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	s.SaveHistory(&store.HistoryRecord{
+		ID:            "json-1",
+		Config:        &config.NotificationConfig{Heading: "JSON Test"},
+		ResponseValue: "ok",
+		CompletedAt:   time.Now(),
+	})
+	s.Close()
+
+	// printInboxJSON writes to os.Stdout. We verify it doesn't error.
+	// A full stdout capture would require os.Pipe; verifying no error is sufficient.
+	err = printInboxJSON(dbPath)
+	if err != nil {
+		t.Fatalf("printInboxJSON: %v", err)
+	}
+}
+
+func TestFetchHistory_DirectDB(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "fetch.db")
+	s, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	s.SaveHistory(&store.HistoryRecord{
+		ID:          "fh-1",
+		Config:      &config.NotificationConfig{Heading: "Fetch"},
+		CompletedAt: time.Now(),
+	})
+	s.Close()
+
+	entries, err := fetchHistory(dbPath)
+	if err != nil {
+		t.Fatalf("fetchHistory: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("expected 1 entry, got %d", len(entries))
+	}
+}

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -1,0 +1,128 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAppendLineIfMissing(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates file when missing", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "sub", "profile.ps1")
+		err := appendLineIfMissing(path, "hermes motd # Hermes-MOTD", motdMarker)
+		if err != nil {
+			t.Fatalf("appendLineIfMissing: %v", err)
+		}
+		got, _ := os.ReadFile(path)
+		if !strings.Contains(string(got), "hermes motd") {
+			t.Errorf("file content = %q, want contains 'hermes motd'", got)
+		}
+	})
+
+	t.Run("idempotent when marker present", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "profile.sh")
+		os.WriteFile(path, []byte("existing content\nhermes motd # Hermes-MOTD\n"), 0644)
+
+		err := appendLineIfMissing(path, "hermes motd # Hermes-MOTD", motdMarker)
+		if err != nil {
+			t.Fatalf("appendLineIfMissing: %v", err)
+		}
+
+		got, _ := os.ReadFile(path)
+		if count := strings.Count(string(got), motdMarker); count != 1 {
+			t.Errorf("marker appears %d times, want 1", count)
+		}
+	})
+
+	t.Run("appends newline when file lacks trailing newline", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "profile.sh")
+		os.WriteFile(path, []byte("existing content"), 0644)
+
+		err := appendLineIfMissing(path, "hermes motd # Hermes-MOTD", motdMarker)
+		if err != nil {
+			t.Fatalf("appendLineIfMissing: %v", err)
+		}
+
+		got, _ := os.ReadFile(path)
+		lines := strings.Split(string(got), "\n")
+		if len(lines) < 3 {
+			t.Fatalf("expected at least 3 lines (original, blank, hook), got %d", len(lines))
+		}
+	})
+
+	t.Run("appends to empty file", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "profile.sh")
+		os.WriteFile(path, []byte(""), 0644)
+
+		err := appendLineIfMissing(path, "hermes motd # Hermes-MOTD", motdMarker)
+		if err != nil {
+			t.Fatalf("appendLineIfMissing: %v", err)
+		}
+
+		got, _ := os.ReadFile(path)
+		if !strings.Contains(string(got), motdMarker) {
+			t.Errorf("file content = %q, want contains marker", got)
+		}
+	})
+}
+
+func TestWriteFileIfMissing(t *testing.T) {
+	t.Parallel()
+
+	t.Run("creates file when absent", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "sub", "hermes-motd.sh")
+		content := "command -v hermes >/dev/null 2>&1 && hermes motd # Hermes-MOTD\n"
+
+		err := writeFileIfMissing(path, content, 0644)
+		if err != nil {
+			t.Fatalf("writeFileIfMissing: %v", err)
+		}
+
+		got, _ := os.ReadFile(path)
+		if string(got) != content {
+			t.Errorf("file content = %q, want %q", got, content)
+		}
+	})
+
+	t.Run("idempotent when marker present", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "hermes-motd.sh")
+		original := "old content # Hermes-MOTD\n"
+		os.WriteFile(path, []byte(original), 0644)
+
+		err := writeFileIfMissing(path, "new content # Hermes-MOTD\n", 0644)
+		if err != nil {
+			t.Fatalf("writeFileIfMissing: %v", err)
+		}
+
+		got, _ := os.ReadFile(path)
+		if string(got) != original {
+			t.Errorf("file was overwritten: got %q, want %q", got, original)
+		}
+	})
+
+	t.Run("overwrites when no marker", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "hermes-motd.sh")
+		os.WriteFile(path, []byte("unrelated content\n"), 0644)
+
+		content := "hermes motd # Hermes-MOTD\n"
+		err := writeFileIfMissing(path, content, 0644)
+		if err != nil {
+			t.Fatalf("writeFileIfMissing: %v", err)
+		}
+
+		got, _ := os.ReadFile(path)
+		if string(got) != content {
+			t.Errorf("file content = %q, want %q", got, content)
+		}
+	})
+}

--- a/cmd/motd_test.go
+++ b/cmd/motd_test.go
@@ -1,0 +1,129 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/TsekNet/hermes/internal/config"
+	"github.com/TsekNet/hermes/internal/store"
+)
+
+func TestSanitize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"clean string unchanged", "Hello World", "Hello World"},
+		{"strips null byte", "Hello\x00World", "HelloWorld"},
+		{"strips newline", "Hello\nWorld", "HelloWorld"},
+		{"strips tab", "Hello\tWorld", "HelloWorld"},
+		{"strips carriage return", "Hello\rWorld", "HelloWorld"},
+		{"strips DEL 0x7f", "Hello\x7fWorld", "HelloWorld"},
+		{"strips C1 U+0085 NEL", "HelloWorld", "HelloWorld"},
+		{"strips C1 U+0080", "HelloWorld", "HelloWorld"},
+		{"strips C1 U+009F", "HelloWorld", "HelloWorld"},
+		{"preserves em dash", "Hermes — notification", "Hermes — notification"},
+		{"preserves emoji", "Update ready \U0001F680", "Update ready \U0001F680"},
+		{"empty string", "", ""},
+		{"only ASCII controls", "\x00\x01\x02\x1f\x7f", ""},
+		{"mixed controls and text", "Re\x00boot\x1frequi\x7fred", "Rebootrequired"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := sanitize(tt.input); got != tt.want {
+				t.Errorf("sanitize(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsSSHSession(t *testing.T) {
+	tests := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{"SSH_CLIENT set", map[string]string{"SSH_CLIENT": "192.168.1.1 54321 22"}, true},
+		{"SSH_CONNECTION set", map[string]string{"SSH_CONNECTION": "192.168.1.1 54321 10.0.0.1 22"}, true},
+		{"SSH_TTY set", map[string]string{"SSH_TTY": "/dev/pts/0"}, true},
+		{"no SSH env vars", map[string]string{}, false},
+		{"unrelated env vars", map[string]string{"HOME": "/home/user", "TERM": "xterm"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, key := range []string{"SSH_CLIENT", "SSH_CONNECTION", "SSH_TTY"} {
+				t.Setenv(key, "")
+			}
+			for k, v := range tt.env {
+				t.Setenv(k, v)
+			}
+			if got := isSSHSession(); got != tt.want {
+				t.Errorf("isSSHSession() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunMotd_NoSSH(t *testing.T) {
+	for _, key := range []string{"SSH_CLIENT", "SSH_CONNECTION", "SSH_TTY"} {
+		t.Setenv(key, "")
+	}
+
+	err := runMotd(filepath.Join(t.TempDir(), "unused.db"))
+	if err != nil {
+		t.Fatalf("runMotd should return nil when not SSH: %v", err)
+	}
+}
+
+func TestRunMotd_SSHWithHistory(t *testing.T) {
+	t.Setenv("SSH_CLIENT", "192.168.1.1 54321 22")
+	t.Setenv("SSH_CONNECTION", "")
+	t.Setenv("SSH_TTY", "")
+
+	dbPath := filepath.Join(t.TempDir(), "motd.db")
+	s, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	now := time.Now()
+	for i := range 7 {
+		s.SaveHistory(&store.HistoryRecord{
+			ID:          fmt.Sprintf("h-%d", i),
+			Config:      &config.NotificationConfig{Heading: fmt.Sprintf("Notification %d", i)},
+			CompletedAt: now.Add(time.Duration(i) * time.Minute),
+		})
+	}
+	s.Close()
+
+	// runMotd prints to stdout; we just verify no error.
+	err = runMotd(dbPath)
+	if err != nil {
+		t.Fatalf("runMotd: %v", err)
+	}
+}
+
+func TestRunMotd_SSHEmptyHistory(t *testing.T) {
+	t.Setenv("SSH_CLIENT", "192.168.1.1 54321 22")
+	t.Setenv("SSH_CONNECTION", "")
+	t.Setenv("SSH_TTY", "")
+
+	dbPath := filepath.Join(t.TempDir(), "empty.db")
+	s, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	s.Close()
+
+	err = runMotd(dbPath)
+	if err != nil {
+		t.Fatalf("runMotd: %v", err)
+	}
+}

--- a/cmd/notify_test.go
+++ b/cmd/notify_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/TsekNet/hermes/internal/config"
+)
+
+func TestWriteTempConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("roundtrips config through JSON", func(t *testing.T) {
+		t.Parallel()
+		cfg := &config.NotificationConfig{
+			Heading: "Reboot Required",
+			Message: "Please save your work and restart.",
+			Buttons: []config.Button{
+				{Label: "Restart Now", Value: "restart", Style: "primary"},
+				{Label: "Later", Value: "defer:1h"},
+			},
+		}
+
+		path, err := writeTempConfig(cfg)
+		if err != nil {
+			t.Fatalf("writeTempConfig: %v", err)
+		}
+		t.Cleanup(func() { os.RemoveAll(filepath.Dir(path)) })
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read temp config: %v", err)
+		}
+
+		var got config.NotificationConfig
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+
+		if got.Heading != cfg.Heading {
+			t.Errorf("heading = %q, want %q", got.Heading, cfg.Heading)
+		}
+		if len(got.Buttons) != 2 {
+			t.Errorf("buttons = %d, want 2", len(got.Buttons))
+		}
+	})
+
+	t.Run("file has expected name", func(t *testing.T) {
+		t.Parallel()
+		cfg := &config.NotificationConfig{Heading: "H", Message: "M"}
+		path, err := writeTempConfig(cfg)
+		if err != nil {
+			t.Fatalf("writeTempConfig: %v", err)
+		}
+		t.Cleanup(func() { os.RemoveAll(filepath.Dir(path)) })
+
+		if filepath.Base(path) != "config.json" {
+			t.Errorf("filename = %q, want config.json", filepath.Base(path))
+		}
+	})
+
+	t.Run("directory permissions allow traversal", func(t *testing.T) {
+		t.Parallel()
+		cfg := &config.NotificationConfig{Heading: "H", Message: "M"}
+		path, err := writeTempConfig(cfg)
+		if err != nil {
+			t.Fatalf("writeTempConfig: %v", err)
+		}
+		dir := filepath.Dir(path)
+		t.Cleanup(func() { os.RemoveAll(dir) })
+
+		info, err := os.Stat(dir)
+		if err != nil {
+			t.Fatalf("stat dir: %v", err)
+		}
+		perm := info.Mode().Perm()
+		if perm&0111 == 0 {
+			t.Errorf("dir perm = %o, want execute bits set for traversal", perm)
+		}
+	})
+}

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,14 +1,110 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/TsekNet/hermes/internal/config"
+	"github.com/TsekNet/hermes/internal/exitcodes"
 )
+
+func TestBuildRootCmd_SubcommandErrors(t *testing.T) {
+	// These tests exercise Cobra command construction, flag parsing, and
+	// early error paths. They share package-level flag vars, so they
+	// run sequentially within this top-level test.
+
+	t.Run("notify no config", func(t *testing.T) {
+		cmd := buildRootCmd()
+		cmd.SetArgs([]string{"notify"})
+		if err := cmd.Execute(); err == nil {
+			t.Fatal("notify with no config should error")
+		}
+	})
+
+	t.Run("stop no service", func(t *testing.T) {
+		cmd := buildRootCmd()
+		cmd.SetArgs([]string{"stop"})
+		if err := cmd.Execute(); err == nil {
+			t.Fatal("stop with no running service should error")
+		}
+	})
+
+	t.Run("list no service", func(t *testing.T) {
+		cmd := buildRootCmd()
+		cmd.SetArgs([]string{"list"})
+		if err := cmd.Execute(); err == nil {
+			t.Fatal("list with no running service should error")
+		}
+	})
+
+	t.Run("cancel no service", func(t *testing.T) {
+		cmd := buildRootCmd()
+		cmd.SetArgs([]string{"cancel", "test-id"})
+		if err := cmd.Execute(); err == nil {
+			t.Fatal("cancel with no running service should error")
+		}
+	})
+
+	t.Run("notify inline JSON no service", func(t *testing.T) {
+		cmd := buildRootCmd()
+		cmd.SetArgs([]string{"notify", `{"heading":"Test","message":"M"}`})
+		if err := cmd.Execute(); err == nil {
+			t.Skip("service running, cannot test offline path")
+		}
+	})
+
+	t.Run("inbox JSON", func(t *testing.T) {
+		dbPath := filepath.Join(t.TempDir(), "inbox-cmd.db")
+		cmd := buildRootCmd()
+		cmd.SetArgs([]string{"inbox", "--json", "--db", dbPath})
+		cmd.Execute()
+	})
+}
+
+func TestResolveConfig_Stdin(t *testing.T) {
+	// resolveConfig reads stdin when no flag and no args, and stdin is a pipe.
+	// In test context, stdin is /dev/null (not a char device), so depending
+	// on the test runner it may or may not trigger the stdin path.
+	// We test the explicit paths that don't depend on stdin state.
+	t.Parallel()
+
+	t.Run("oversized stdin arg returns error", func(t *testing.T) {
+		t.Parallel()
+		// loadFromArg with JSON too large should error at config.Load level.
+		huge := `{"heading":"` + strings.Repeat("X", 2*1024*1024) + `"}`
+		_, err := loadFromArg(huge)
+		if err == nil {
+			t.Fatal("expected error for oversized config")
+		}
+	})
+}
+
+func TestBuildRootCmd(t *testing.T) {
+	t.Parallel()
+	cmd := buildRootCmd()
+
+	if cmd.Use != "hermes [config]" {
+		t.Errorf("Use = %q", cmd.Use)
+	}
+
+	wantSubs := []string{"demo", "version", "serve", "notify", "list",
+		"cancel", "inbox", "stop", "motd", "install", "uninstall"}
+	gotSubs := make(map[string]bool)
+	for _, sub := range cmd.Commands() {
+		gotSubs[sub.Name()] = true
+	}
+
+	for _, want := range wantSubs {
+		if !gotSubs[want] {
+			t.Errorf("missing subcommand: %s", want)
+		}
+	}
+}
 
 func TestResolveConfig_NoInput(t *testing.T) {
 	t.Parallel()
@@ -181,6 +277,56 @@ func TestLoadFromArg_InvalidPath(t *testing.T) {
 	}
 }
 
+func TestLoadFromArg_InlineYAML(t *testing.T) {
+	t.Parallel()
+	cfg, err := loadFromArg("heading: YAMLTest\nmessage: body")
+	if err != nil {
+		t.Fatalf("loadFromArg: %v", err)
+	}
+	if cfg.Heading != "YAMLTest" {
+		t.Errorf("heading = %q, want YAMLTest", cfg.Heading)
+	}
+}
+
+func TestLoadFromArg_FileOverInline(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// Create a file whose name looks like JSON but is actually a file path.
+	path := filepath.Join(dir, "config.json")
+	os.WriteFile(path, []byte(`{"heading":"FromFile"}`), 0644)
+
+	cfg, err := loadFromArg(path)
+	if err != nil {
+		t.Fatalf("loadFromArg: %v", err)
+	}
+	if cfg.Heading != "FromFile" {
+		t.Errorf("heading = %q, want FromFile (file takes precedence)", cfg.Heading)
+	}
+}
+
+func TestLoadFromArg_GarbageString(t *testing.T) {
+	t.Parallel()
+	_, err := loadFromArg("not-json-not-file-not-yaml")
+	if err == nil {
+		t.Fatal("expected error for garbage string")
+	}
+}
+
+func TestResolveConfig_FlagOverArg(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	flagFile := filepath.Join(dir, "flag.json")
+	os.WriteFile(flagFile, []byte(`{"heading":"Flag"}`), 0644)
+
+	cfg, err := resolveConfig(flagFile, []string{`{"heading":"Arg"}`})
+	if err != nil {
+		t.Fatalf("resolveConfig: %v", err)
+	}
+	if cfg.Heading != "Flag" {
+		t.Errorf("heading = %q, want Flag (--config flag takes precedence)", cfg.Heading)
+	}
+}
+
 func TestWebView2DataPath_NonWindowsReturnsEmpty(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test only applies on non-Windows")
@@ -188,5 +334,171 @@ func TestWebView2DataPath_NonWindowsReturnsEmpty(t *testing.T) {
 	t.Setenv("LOCALAPPDATA", t.TempDir())
 	if p := webview2DataPath(); p != "" {
 		t.Errorf("expected empty string on %s, got %q", runtime.GOOS, p)
+	}
+}
+
+func TestFilterDeferButtons(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		buttons    []config.Button
+		wantLabels []string
+	}{
+		{
+			name:       "nil buttons",
+			buttons:    nil,
+			wantLabels: nil,
+		},
+		{
+			name: "no defers unchanged",
+			buttons: []config.Button{
+				{Label: "OK", Value: "ok"},
+				{Label: "Cancel", Value: "cancel"},
+			},
+			wantLabels: []string{"OK", "Cancel"},
+		},
+		{
+			name: "top-level defer removed",
+			buttons: []config.Button{
+				{Label: "OK", Value: "ok"},
+				{Label: "Later", Value: "defer"},
+				{Label: "Defer 1h", Value: "defer:1h"},
+			},
+			wantLabels: []string{"OK"},
+		},
+		{
+			name: "dropdown defer options removed",
+			buttons: []config.Button{
+				{Label: "Schedule", Value: "schedule", Dropdown: []config.DropdownOption{
+					{Label: "1 hour", Value: "defer:1h"},
+					{Label: "Tomorrow", Value: "defer:24h"},
+					{Label: "Custom", Value: "custom"},
+				}},
+			},
+			wantLabels: []string{"Schedule"},
+		},
+		{
+			name: "dropdown-only button with empty value dropped when all options are defers",
+			buttons: []config.Button{
+				{Label: "Defer", Value: "", Dropdown: []config.DropdownOption{
+					{Label: "1 hour", Value: "defer:1h"},
+					{Label: "4 hours", Value: "defer:4h"},
+				}},
+				{Label: "OK", Value: "ok"},
+			},
+			wantLabels: []string{"OK"},
+		},
+		{
+			name: "dropdown-only button with base value kept when dropdown empties",
+			buttons: []config.Button{
+				{Label: "Snooze", Value: "snooze", Dropdown: []config.DropdownOption{
+					{Label: "1 hour", Value: "defer:1h"},
+				}},
+			},
+			wantLabels: []string{"Snooze"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := filterDeferButtons(tt.buttons)
+
+			if tt.wantLabels == nil {
+				if got != nil {
+					t.Fatalf("got %d buttons, want nil", len(got))
+				}
+				return
+			}
+
+			if len(got) != len(tt.wantLabels) {
+				labels := make([]string, len(got))
+				for i, b := range got {
+					labels[i] = b.Label
+				}
+				t.Fatalf("labels = %v, want %v", labels, tt.wantLabels)
+			}
+
+			for i, want := range tt.wantLabels {
+				if got[i].Label != want {
+					t.Errorf("button[%d].Label = %q, want %q", i, got[i].Label, want)
+				}
+			}
+		})
+	}
+}
+
+func TestFilterDeferButtons_DropdownNonDeferOptionsPreserved(t *testing.T) {
+	t.Parallel()
+	buttons := []config.Button{
+		{Label: "Actions", Value: "", Dropdown: []config.DropdownOption{
+			{Label: "Restart", Value: "restart"},
+			{Label: "Defer 1h", Value: "defer:1h"},
+			{Label: "Shutdown", Value: "shutdown"},
+		}},
+	}
+	got := filterDeferButtons(buttons)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 button, got %d", len(got))
+	}
+	if len(got[0].Dropdown) != 2 {
+		t.Fatalf("dropdown options = %d, want 2", len(got[0].Dropdown))
+	}
+	if got[0].Dropdown[0].Value != "restart" {
+		t.Errorf("dropdown[0].Value = %q, want restart", got[0].Dropdown[0].Value)
+	}
+	if got[0].Dropdown[1].Value != "shutdown" {
+		t.Errorf("dropdown[1].Value = %q, want shutdown", got[0].Dropdown[1].Value)
+	}
+}
+
+func TestRespond_ExitCodes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		value    string
+		wantCode int
+		wantOut  string
+	}{
+		{"empty_value", "", 0, ""},
+		{"timeout_prefix", "timeout:restart", int(exitcodes.Timeout), "restart"},
+		{"deferred", "defer", int(exitcodes.Deferred), "defer"},
+		{"normal_ok", "ok", int(exitcodes.OK), "ok"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if os.Getenv("TEST_RESPOND_SUBPROCESS") == "1" {
+				respond(os.Getenv("TEST_RESPOND_VALUE"))
+				return
+			}
+
+			cmd := exec.Command(os.Args[0],
+				fmt.Sprintf("-test.run=^TestRespond_ExitCodes/%s$", tt.name),
+			)
+			cmd.Env = append(os.Environ(),
+				"TEST_RESPOND_SUBPROCESS=1",
+				"TEST_RESPOND_VALUE="+tt.value,
+			)
+			out, err := cmd.Output()
+
+			gotCode := 0
+			if exitErr, ok := err.(*exec.ExitError); ok {
+				gotCode = exitErr.ExitCode()
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if gotCode != tt.wantCode {
+				t.Errorf("exit code = %d, want %d", gotCode, tt.wantCode)
+			}
+			if string(out) != tt.wantOut {
+				t.Errorf("stdout = %q, want %q", string(out), tt.wantOut)
+			}
+		})
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -50,14 +50,6 @@ func TestBuildRootCmd_SubcommandErrors(t *testing.T) {
 		}
 	})
 
-	t.Run("notify inline JSON no service", func(t *testing.T) {
-		cmd := buildRootCmd()
-		cmd.SetArgs([]string{"notify", `{"heading":"Test","message":"M"}`})
-		if err := cmd.Execute(); err == nil {
-			t.Skip("service running, cannot test offline path")
-		}
-	})
-
 	t.Run("inbox JSON", func(t *testing.T) {
 		dbPath := filepath.Join(t.TempDir(), "inbox-cmd.db")
 		cmd := buildRootCmd()

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/TsekNet/hermes/internal/config"
+	"github.com/TsekNet/hermes/internal/store"
+)
+
+func TestServeCmd_Flags(t *testing.T) {
+	t.Parallel()
+	cmd := serveCmd()
+
+	if cmd.Use != "serve" {
+		t.Errorf("Use = %q, want serve", cmd.Use)
+	}
+
+	db := cmd.Flags().Lookup("db")
+	if db == nil {
+		t.Fatal("missing --db flag")
+	}
+	noTray := cmd.Flags().Lookup("no-tray")
+	if noTray == nil {
+		t.Fatal("missing --no-tray flag")
+	}
+}
+
+func TestSortByDependencies(t *testing.T) {
+	t.Parallel()
+
+	qr := func(id, dependsOn string) *store.QueueRecord {
+		return &store.QueueRecord{
+			ID:     id,
+			Config: &config.NotificationConfig{ID: id, DependsOn: dependsOn},
+		}
+	}
+
+	tests := []struct {
+		name    string
+		input   []*store.QueueRecord
+		wantIDs []string
+	}{
+		{
+			name:    "empty input",
+			input:   nil,
+			wantIDs: nil,
+		},
+		{
+			name:    "single item",
+			input:   []*store.QueueRecord{qr("a", "")},
+			wantIDs: []string{"a"},
+		},
+		{
+			name:    "no dependencies preserves order",
+			input:   []*store.QueueRecord{qr("a", ""), qr("b", ""), qr("c", "")},
+			wantIDs: []string{"a", "b", "c"},
+		},
+		{
+			name:    "linear chain reordered",
+			input:   []*store.QueueRecord{qr("c", "b"), qr("b", "a"), qr("a", "")},
+			wantIDs: []string{"a", "b", "c"},
+		},
+		{
+			name:    "diamond dependency",
+			input:   []*store.QueueRecord{qr("d", "b"), qr("c", "a"), qr("b", "a"), qr("a", "")},
+			wantIDs: []string{"a", "b", "d", "c"},
+		},
+		{
+			name:    "dependency on item not in queue",
+			input:   []*store.QueueRecord{qr("b", "missing"), qr("a", "")},
+			wantIDs: []string{"b", "a"},
+		},
+		{
+			name:    "mutual cycle does not hang",
+			input:   []*store.QueueRecord{qr("a", "b"), qr("b", "a")},
+			wantIDs: []string{"b", "a"},
+		},
+		{
+			name:    "self-referencing dependency",
+			input:   []*store.QueueRecord{qr("a", "a")},
+			wantIDs: []string{"a"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := sortByDependencies(tt.input)
+
+			if len(got) != len(tt.input) {
+				t.Fatalf("len = %d, want %d", len(got), len(tt.input))
+			}
+
+			if tt.wantIDs == nil {
+				return
+			}
+
+			for i, want := range tt.wantIDs {
+				if got[i].ID != want {
+					ids := make([]string, len(got))
+					for j, r := range got {
+						ids[j] = r.ID
+					}
+					t.Fatalf("order = %v, want %v", ids, tt.wantIDs)
+				}
+			}
+		})
+	}
+}

--- a/cmd/sessionlaunch_unix_test.go
+++ b/cmd/sessionlaunch_unix_test.go
@@ -1,0 +1,75 @@
+//go:build !windows
+
+package cmd
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestBuildUserEnv(t *testing.T) {
+	t.Parallel()
+
+	s := userSession{
+		uid:      1001,
+		gid:      1001,
+		username: "jdoe",
+		home:     "/home/jdoe",
+	}
+
+	env := buildUserEnv(s)
+	envMap := make(map[string]string)
+	for _, e := range env {
+		parts := strings.SplitN(e, "=", 2)
+		if len(parts) == 2 {
+			envMap[parts[0]] = parts[1]
+		}
+	}
+
+	tests := []struct {
+		key  string
+		want string
+	}{
+		{"HOME", "/home/jdoe"},
+		{"USER", "jdoe"},
+		{"LOGNAME", "jdoe"},
+		{"SHELL", "/bin/sh"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.key, func(t *testing.T) {
+			t.Parallel()
+			if got := envMap[tt.key]; got != tt.want {
+				t.Errorf("%s = %q, want %q", tt.key, got, tt.want)
+			}
+		})
+	}
+
+	if _, ok := envMap["PATH"]; !ok {
+		t.Error("PATH not set")
+	}
+
+	if runtime.GOOS == "linux" {
+		t.Run("linux XDG vars", func(t *testing.T) {
+			if envMap["XDG_RUNTIME_DIR"] != "/run/user/1001" {
+				t.Errorf("XDG_RUNTIME_DIR = %q, want /run/user/1001", envMap["XDG_RUNTIME_DIR"])
+			}
+			if envMap["DISPLAY"] != ":0" {
+				t.Errorf("DISPLAY = %q, want :0", envMap["DISPLAY"])
+			}
+			if !strings.Contains(envMap["DBUS_SESSION_BUS_ADDRESS"], "/run/user/1001/bus") {
+				t.Errorf("DBUS_SESSION_BUS_ADDRESS = %q, want to contain /run/user/1001/bus", envMap["DBUS_SESSION_BUS_ADDRESS"])
+			}
+		})
+	}
+}
+
+func TestIsPrivileged(t *testing.T) {
+	t.Parallel()
+	got := isPrivileged()
+	// In test context, we're not root.
+	if got {
+		t.Skip("running as root, cannot verify non-privileged path")
+	}
+}

--- a/cmd/stop_test.go
+++ b/cmd/stop_test.go
@@ -1,0 +1,31 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestWaitForSocketRemoval_AlreadyGone(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "hermes.sock")
+	got := waitForSocketRemoval(path, 100*time.Millisecond)
+	if !got {
+		t.Error("expected true when socket already absent")
+	}
+}
+
+func TestWaitForSocketRemoval_Timeout(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hermes.sock")
+
+	// Create a regular file to simulate a socket that never disappears.
+	// socket.IsRunning uses net.Dial, which won't connect to a regular file,
+	// so this returns false immediately (socket gone).
+	// This tests the "already removed" path with a very short timeout.
+	got := waitForSocketRemoval(path, 50*time.Millisecond)
+	if !got {
+		t.Error("expected true: non-socket file causes IsRunning to return false")
+	}
+}

--- a/cmd/uninstall_test.go
+++ b/cmd/uninstall_test.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRemoveLinesWithMarker(t *testing.T) {
+	t.Parallel()
+
+	t.Run("removes matching lines", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "profile.sh")
+		content := "line one\nhermes motd # Hermes-MOTD\nline three\n"
+		os.WriteFile(path, []byte(content), 0644)
+
+		err := removeLinesWithMarker(path, motdMarker)
+		if err != nil {
+			t.Fatalf("removeLinesWithMarker: %v", err)
+		}
+
+		got, _ := os.ReadFile(path)
+		want := "line one\nline three\n"
+		if string(got) != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("no-op when marker absent", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "profile.sh")
+		content := "line one\nline two\n"
+		os.WriteFile(path, []byte(content), 0644)
+
+		err := removeLinesWithMarker(path, motdMarker)
+		if err != nil {
+			t.Fatalf("removeLinesWithMarker: %v", err)
+		}
+
+		got, _ := os.ReadFile(path)
+		if string(got) != content {
+			t.Errorf("file was modified: got %q, want %q", got, content)
+		}
+	})
+
+	t.Run("no-op when file missing", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "nonexistent.sh")
+		err := removeLinesWithMarker(path, motdMarker)
+		if err != nil {
+			t.Fatalf("expected nil for missing file, got: %v", err)
+		}
+	})
+
+	t.Run("removes multiple matching lines", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "profile.sh")
+		content := "first # Hermes-MOTD\nkeep\nsecond # Hermes-MOTD\n"
+		os.WriteFile(path, []byte(content), 0644)
+
+		err := removeLinesWithMarker(path, motdMarker)
+		if err != nil {
+			t.Fatalf("removeLinesWithMarker: %v", err)
+		}
+
+		got, _ := os.ReadFile(path)
+		want := "keep\n"
+		if string(got) != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,12 @@
+package cmd
+
+import "testing"
+
+func TestVersionCmd_NoPanic(t *testing.T) {
+	t.Parallel()
+	cmd := versionCmd()
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("version command: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/TsekNet/hermes
 
-go 1.25.0
+go 1.26.0
 
 require (
 	fyne.io/systray v1.12.1

--- a/internal/app/inbox_test.go
+++ b/internal/app/inbox_test.go
@@ -1,0 +1,265 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/TsekNet/hermes/internal/client"
+	"github.com/TsekNet/hermes/internal/config"
+	"github.com/TsekNet/hermes/internal/store"
+)
+
+func TestInboxEntryFromRecord(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+	completed := time.Date(2025, 6, 15, 10, 5, 0, 0, time.UTC)
+
+	r := &store.HistoryRecord{
+		ID: "h-42",
+		Config: &config.NotificationConfig{
+			Heading: "Reboot Required",
+			Message: "Please restart your machine.",
+			Title:   "IT Notifications",
+		},
+		ResponseValue: "restart",
+		CreatedAt:     created,
+		CompletedAt:   completed,
+	}
+
+	got := InboxEntryFromRecord(r)
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"ID", got.ID, "h-42"},
+		{"Heading", got.Heading, "Reboot Required"},
+		{"Message", got.Message, "Please restart your machine."},
+		{"Source", got.Source, "IT Notifications"},
+		{"ResponseValue", got.ResponseValue, "restart"},
+		{"CreatedAt", got.CreatedAt, created.Format(time.RFC3339)},
+		{"CompletedAt", got.CompletedAt, completed.Format(time.RFC3339)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.got != tt.want {
+				t.Errorf("%s = %q, want %q", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInboxEntryFromClientEntry_Completed(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2025, 7, 1, 12, 0, 0, 0, time.UTC)
+	completed := time.Date(2025, 7, 1, 12, 30, 0, 0, time.UTC)
+
+	e := client.HistoryEntry{
+		ID:             "ce-1",
+		Heading:        "Update Available",
+		Message:        "Version 2.0",
+		Source:         "Software Updates",
+		ResponseValue:  "dismiss",
+		CreatedAt:      created,
+		CompletedAt:    completed,
+		ActionRequired: false,
+	}
+
+	got := InboxEntryFromClientEntry(e)
+
+	if got.ActionRequired {
+		t.Error("ActionRequired should be false for completed entry")
+	}
+	if len(got.Buttons) != 0 {
+		t.Errorf("Buttons = %d, want 0 for completed entry", len(got.Buttons))
+	}
+	if got.Heading != "Update Available" {
+		t.Errorf("Heading = %q, want %q", got.Heading, "Update Available")
+	}
+}
+
+func TestInboxEntryFromClientEntry_ActiveWithButtons(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.NotificationConfig{
+		Heading: "Reboot",
+		Message: "Reboot needed",
+		Buttons: []config.Button{
+			{Label: "Restart Now", Value: "restart", Style: "primary"},
+			{Label: "Later", Value: "defer:1h"},
+		},
+	}
+	cfgJSON, _ := json.Marshal(cfg)
+
+	e := client.HistoryEntry{
+		ID:             "active-1",
+		Heading:        "Reboot",
+		Message:        "Reboot needed",
+		ActionRequired: true,
+		ConfigJSON:     cfgJSON,
+		CreatedAt:      time.Now(),
+	}
+
+	got := InboxEntryFromClientEntry(e)
+
+	if !got.ActionRequired {
+		t.Error("ActionRequired should be true")
+	}
+	if len(got.Buttons) != 2 {
+		t.Fatalf("Buttons = %d, want 2", len(got.Buttons))
+	}
+	if got.Buttons[0].Label != "Restart Now" {
+		t.Errorf("Buttons[0].Label = %q, want %q", got.Buttons[0].Label, "Restart Now")
+	}
+	if got.Buttons[0].Style != "primary" {
+		t.Errorf("Buttons[0].Style = %q, want %q", got.Buttons[0].Style, "primary")
+	}
+	if got.Buttons[1].Value != "defer:1h" {
+		t.Errorf("Buttons[1].Value = %q, want %q", got.Buttons[1].Value, "defer:1h")
+	}
+}
+
+func TestInboxEntryFromClientEntry_ActiveEmptyConfigJSON(t *testing.T) {
+	t.Parallel()
+
+	e := client.HistoryEntry{
+		ID:             "active-2",
+		ActionRequired: true,
+		ConfigJSON:     nil,
+		CreatedAt:      time.Now(),
+	}
+
+	got := InboxEntryFromClientEntry(e)
+
+	if len(got.Buttons) != 0 {
+		t.Errorf("Buttons = %d, want 0 when ConfigJSON is nil", len(got.Buttons))
+	}
+}
+
+func TestInboxEntryFromClientEntry_ActiveInvalidConfigJSON(t *testing.T) {
+	t.Parallel()
+
+	e := client.HistoryEntry{
+		ID:             "active-3",
+		ActionRequired: true,
+		ConfigJSON:     []byte("{invalid json"),
+		CreatedAt:      time.Now(),
+	}
+
+	got := InboxEntryFromClientEntry(e)
+
+	if len(got.Buttons) != 0 {
+		t.Errorf("Buttons = %d, want 0 when ConfigJSON is invalid", len(got.Buttons))
+	}
+}
+
+func TestNewInbox(t *testing.T) {
+	t.Parallel()
+	app := NewInbox(nil)
+	if app.grpcClient != nil {
+		t.Error("grpcClient should be nil when passed nil")
+	}
+}
+
+func TestNewInboxLocal(t *testing.T) {
+	t.Parallel()
+	app := NewInboxLocal(nil)
+	if app.localStore != nil {
+		t.Error("localStore should be nil when passed nil")
+	}
+}
+
+func TestGetHistory_NilStore(t *testing.T) {
+	t.Parallel()
+	app := &InboxApp{}
+	got := app.GetHistory()
+	if got != nil {
+		t.Errorf("GetHistory = %v, want nil with no client or store", got)
+	}
+}
+
+func TestRespondToNotification_NoClient(t *testing.T) {
+	t.Parallel()
+	app := &InboxApp{}
+	got := app.RespondToNotification("id", "ok")
+	if got != "error: no service connection" {
+		t.Errorf("got %q, want 'error: no service connection'", got)
+	}
+}
+
+func TestHistoryFromStore(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "inbox-store.db")
+	s, err := store.Open(dbPath)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { s.Close() })
+
+	now := time.Now()
+	s.SaveHistory(&store.HistoryRecord{
+		ID:            "hs-1",
+		Config:        &config.NotificationConfig{Heading: "Valid", Message: "body"},
+		ResponseValue: "ok",
+		CompletedAt:   now,
+	})
+	// Record with nil config should be skipped.
+	s.SaveHistory(&store.HistoryRecord{
+		ID:          "hs-nil",
+		Config:      nil,
+		CompletedAt: now.Add(-time.Hour),
+	})
+
+	app := NewInboxLocal(s)
+	entries := app.GetHistory()
+
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry (nil config skipped), got %d", len(entries))
+	}
+	if entries[0].Heading != "Valid" {
+		t.Errorf("heading = %q, want Valid", entries[0].Heading)
+	}
+}
+
+func TestHistoryFromStore_NilStore(t *testing.T) {
+	t.Parallel()
+	app := &InboxApp{}
+	entries := app.historyFromStore()
+	if entries != nil {
+		t.Errorf("expected nil with no store, got %d entries", len(entries))
+	}
+}
+
+func TestRunAction_URIPrefix(t *testing.T) {
+	t.Parallel()
+	app := &InboxApp{}
+
+	got := app.RunAction("id", "some-non-uri-value")
+	if got != "some-non-uri-value" {
+		t.Errorf("RunAction non-URI = %q, want passthrough", got)
+	}
+}
+
+func TestInboxApp_Startup(t *testing.T) {
+	t.Parallel()
+	app := &InboxApp{}
+	ctx := context.Background()
+	app.Startup(ctx)
+	if app.ctx != ctx {
+		t.Error("ctx not set")
+	}
+}
+
+func TestInboxApp_Shutdown_NilFields(t *testing.T) {
+	t.Parallel()
+	app := &InboxApp{}
+	app.Shutdown(context.Background())
+}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -153,3 +153,70 @@ func TestPerRPCCredentials(t *testing.T) {
 		t.Error("should not require transport security (localhost only)")
 	}
 }
+
+func TestGenerateToken_Unique(t *testing.T) {
+	dir := t.TempDir()
+	orig := TokenPath
+	TokenPath = func() string { return filepath.Join(dir, "session.token") }
+	t.Cleanup(func() { TokenPath = orig })
+
+	t1, _ := GenerateToken()
+	t2, _ := GenerateToken()
+	if t1 == t2 {
+		t.Error("two generated tokens should differ")
+	}
+}
+
+func TestGenerateToken_CreatesParentDir(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "nested", "deep")
+	orig := TokenPath
+	TokenPath = func() string { return filepath.Join(dir, "session.token") }
+	t.Cleanup(func() { TokenPath = orig })
+
+	_, err := GenerateToken()
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+
+	if _, err := os.Stat(dir); err != nil {
+		t.Errorf("parent dir not created: %v", err)
+	}
+}
+
+func TestRemoveToken_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	orig := TokenPath
+	TokenPath = func() string { return filepath.Join(dir, "session.token") }
+	t.Cleanup(func() { TokenPath = orig })
+
+	RemoveToken()
+	RemoveToken()
+}
+
+func TestLoadToken_TrimsWhitespace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.token")
+	orig := TokenPath
+	TokenPath = func() string { return path }
+	t.Cleanup(func() { TokenPath = orig })
+
+	os.WriteFile(path, []byte("  abc123  \n"), 0600)
+	got, err := LoadToken()
+	if err != nil {
+		t.Fatalf("LoadToken: %v", err)
+	}
+	if got != "abc123" {
+		t.Errorf("LoadToken = %q, want 'abc123'", got)
+	}
+}
+
+func TestTokenPath_ReturnsNonEmpty(t *testing.T) {
+	t.Parallel()
+	p := tokenPath()
+	if p == "" {
+		t.Error("tokenPath() returned empty string")
+	}
+	if !filepath.IsAbs(p) {
+		t.Errorf("tokenPath() = %q, want absolute path", p)
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -407,3 +407,132 @@ func TestReopenPersists(t *testing.T) {
 		t.Fatalf("expected 1 record 'survive' after reopen, got %v", records)
 	}
 }
+
+func TestOpenReadOnly(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "readonly.db")
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	s.SaveHistory(&HistoryRecord{
+		ID:     "h-ro",
+		Config: &config.NotificationConfig{Heading: "ReadOnly"},
+	})
+	s.Close()
+
+	ro, err := OpenReadOnly(path)
+	if err != nil {
+		t.Fatalf("OpenReadOnly: %v", err)
+	}
+	defer ro.Close()
+
+	records, err := ro.LoadHistory()
+	if err != nil {
+		t.Fatalf("LoadHistory: %v", err)
+	}
+	if len(records) != 1 || records[0].ID != "h-ro" {
+		t.Fatalf("expected 1 record 'h-ro', got %v", records)
+	}
+}
+
+func TestOpenReadOnly_MissingFile(t *testing.T) {
+	t.Parallel()
+	_, err := OpenReadOnly(filepath.Join(t.TempDir(), "missing.db"))
+	if err == nil {
+		t.Error("expected error for missing DB file")
+	}
+}
+
+func TestOpen_CreatesParentDir(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "nested", "deep", "test.db")
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	s.Close()
+}
+
+func TestPruneHistory_MaxCountZero(t *testing.T) {
+	t.Parallel()
+	s := tempStore(t)
+
+	now := time.Now()
+	for i := range 5 {
+		s.SaveHistory(&HistoryRecord{
+			ID:          fmt.Sprintf("h-%d", i),
+			Config:      &config.NotificationConfig{Heading: fmt.Sprintf("N%d", i)},
+			CompletedAt: now.Add(time.Duration(i) * time.Minute),
+		})
+	}
+
+	// maxCount=0 is clamped to 1 internally.
+	if err := s.PruneHistory(999*time.Hour, 0); err != nil {
+		t.Fatalf("PruneHistory: %v", err)
+	}
+
+	got, _ := s.LoadHistory()
+	if len(got) != 1 {
+		t.Fatalf("expected 1 record (clamped maxCount=0 to 1), got %d", len(got))
+	}
+}
+
+func TestDefaultPath_NonEmpty(t *testing.T) {
+	t.Parallel()
+	p := defaultPath()
+	if p == "" {
+		t.Error("defaultPath() returned empty string")
+	}
+	if !filepath.IsAbs(p) {
+		t.Errorf("defaultPath() = %q, want absolute path", p)
+	}
+}
+
+func TestEnqueueOffline_GeneratesID(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "autoid.db")
+
+	cfg := &config.NotificationConfig{Heading: "AutoID", Message: "test"}
+	if err := EnqueueOffline(path, cfg, 24*time.Hour); err != nil {
+		t.Fatalf("EnqueueOffline: %v", err)
+	}
+
+	s, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer s.Close()
+
+	records, _ := s.LoadQueue()
+	if len(records) != 1 {
+		t.Fatalf("expected 1 record, got %d", len(records))
+	}
+	if records[0].ID == "" {
+		t.Error("expected auto-generated ID, got empty")
+	}
+	if records[0].ID[:2] != "q-" {
+		t.Errorf("auto-generated ID = %q, want q- prefix", records[0].ID)
+	}
+}
+
+func TestDeleteNonexistentRecord(t *testing.T) {
+	t.Parallel()
+	s := tempStore(t)
+	if err := s.Delete("does-not-exist"); err != nil {
+		t.Errorf("Delete non-existent should not error, got: %v", err)
+	}
+}
+
+func TestLoadAll_EmptyStore(t *testing.T) {
+	t.Parallel()
+	s := tempStore(t)
+	records, err := s.LoadAll()
+	if err != nil {
+		t.Fatalf("LoadAll: %v", err)
+	}
+	if len(records) != 0 {
+		t.Errorf("expected 0 records, got %d", len(records))
+	}
+}


### PR DESCRIPTION
## Summary
- Bump Go to 1.26
- Add table-driven tests for pure logic: sortByDependencies, filterDeferButtons, sanitize, isSSHSession, appendLineIfMissing, writeFileIfMissing, removeLinesWithMarker, writeTempConfig, buildUserEnv, InboxEntryFromRecord, InboxEntryFromClientEntry
- Add integration tests: Cobra command tree, exit code subprocess harness, fetchHistoryFromDB/runMotd with real bbolt fixtures, printInboxJSON
- Extend auth tests: token uniqueness, dir creation, whitespace trimming, idempotent removal, tokenPath validation
- Extend store tests: OpenReadOnly, PruneHistory(maxCount=0), generated queue IDs, nonexistent record deletion, empty store reads
- Coverage: 37.4% to 60.6% (1114/1900 statements)

Remaining uncovered code is Wails UI rendering, systray lifecycle, OS process launching, and syslog/eventlog init, which require runtime resources not available in unit tests.

Ref #24

## Test plan
- [x] go test -race -tags webkit2_41 -count=1 ./internal/... ./cmd/... passes
- [x] go vet -tags webkit2_41 ./... passes
- [ ] CI passes on all platforms (Linux, macOS, Windows)

Generated with [Claude Code](https://claude.com/claude-code)
