### PR TITLE
docs: Add terminal CLI to README and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,14 @@ hermes notify '{"heading":"Restart Required","message":"Please restart.","button
 # Or use --config
 hermes --config notification.json
 
-# List active notifications
+# List active notifications (numbered)
 hermes list
+
+# Show details and available actions by position number
+hermes show 1
+
+# Respond by position number (or interactively with no value)
+hermes respond 1 restart
 
 # View notification history
 hermes history
@@ -95,6 +101,7 @@ The service tracks deferrals per notification, persisted to disk. When the user 
 | **Localization** | `heading_localized` / `message_localized` maps + `--locale` flag for multi-language notifications. |
 | **Dependencies** | Sequential workflows: notification B waits for notification A to complete. |
 | **Broadcast** | Run as SYSTEM/root, auto-delivers to all active user sessions. No wrapper scripts needed. |
+| **Terminal CLI** | Full interaction without a GUI: `hermes list`, `show`, `respond`, `cancel` with numbered positions. Interactive TTY picker. MOTD login banner for SSH sessions. |
 | **System tray icon** | Persistent notification-area icon with pending count and quick history access. Auto-detected on desktop sessions, skipped on headless. |
 | **App launcher shortcut** | "Hermes Notifications" in Start Menu / Spotlight / GNOME Activities. Searchable by name and "notifications" keyword. |
 

--- a/testdata/examples/README.md
+++ b/testdata/examples/README.md
@@ -105,10 +105,38 @@ user@devbox:~$
   * Restart Required
   * VPN Update Available
   * Security Training Due
-Run 'hermes history' for details.
+Run 'hermes list' for details.
 ----------------------------------------
 
 user@devbox:~$
+```
+
+### Terminal CLI
+
+Full notification interaction without a GUI. Position numbers from `hermes list` work with `show`, `respond`, and `cancel`.
+
+```
+$ hermes list
+#   ID               HEADING              STATE              DEFERS   DEADLINE
+1   270c91acbcfd613a System Restart Requi  awaiting_response  0        none
+2   3585d04fee244851 VPN Disconnecting    awaiting_response  0        none
+
+Details: hermes show <#>    Respond: hermes respond <#> <value>
+
+$ hermes show 1
+System Restart Required
+-----------------------
+Your computer needs to restart to apply security updates.
+
+Actions:
+  [1] 1 Hour               (defer_1h)
+  [2] 4 Hours              (defer_4h)
+  [3] Restart Now           (restart)
+
+Respond: hermes respond 270c91acbcfd613a <value>
+
+$ hermes respond 1 restart
+Sent: restart
 ```
 
 ### Notification history


### PR DESCRIPTION
## Summary
- Add Terminal CLI row to README features table
- Add show/respond to Quick Start code block
- Add terminal output examples (list, show, respond) to testdata/examples/README.md
- Fix stale MOTD footer hint (hermes history -> hermes list)

## Test plan
- [x] No PII or internal references
- [x] Examples match actual CLI output

Generated with [Claude Code](https://claude.com/claude-code)